### PR TITLE
Initial trustee-operator support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crds", "operator", "manifest-gen"]
+resolver = "3"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ manifests-dir:
 manifests: tools
 	target/debug/manifest-gen --output-dir manifests \
 		--image $(IMAGE) \
-		--trustee-namespace trustee
+		--trustee-namespace operators
 
 cluster-up:
 	scripts/create-cluster-kind.sh

--- a/README.md
+++ b/README.md
@@ -38,3 +38,31 @@ make REGISTRY=localhost:5000 manifests
 make install-trustee
 make install
 ```
+
+### Test
+
+```bash
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kbs-client
+  namespace: operators
+spec:
+  containers:
+  - name: kbs-client
+    image: quay.io/confidential-containers/kbs-client:v0.13.0
+    imagePullPolicy: IfNotPresent
+    command:
+      - sleep
+      - "360000"
+    env:
+      - name: RUST_LOG
+        value:  none
+EOF
+```
+
+```bash
+# kubectl exec -it kbs-client -n operators -- kbs-client --url http://kbs-service:8080 get-resource --path default/test-secret/key | base64 -d
+test
+```

--- a/crds/src/lib.rs
+++ b/crds/src/lib.rs
@@ -34,21 +34,14 @@ pub struct Trustee {
     namespaced,
     plural = "kbsconfigs"
 )]
+#[serde(rename_all = "camelCase")]
 pub struct KbsConfigSpec {
-    #[serde(rename = "kbsConfigMapName")]
     pub kbs_config_map_name: String,
-    #[serde(rename = "kbsAuthSecretName")]
     pub kbs_auth_secret_name: String,
-    #[serde(rename = "kbsDeploymentType")]
     pub kbs_deployment_type: String,
-    #[serde(rename = "kbsRvpsRefValuesConfigMapName")]
     pub kbs_rvps_ref_values_config_map_name: String,
-    #[serde(rename = "kbsSecretResources")]
     pub kbs_secret_resources: Vec<String>,
-    #[serde(rename = "kbsHttpsKeySecretName")]
     pub kbs_https_key_secret_name: String,
-    #[serde(rename = "kbsHttpsCertSecretName")]
     pub kbs_https_cert_secret_name: String,
-    #[serde(rename = "kbsResourcePolicyConfigMapName")]
     pub kbs_resource_policy_config_map_name: String,
 }

--- a/crds/src/lib.rs
+++ b/crds/src/lib.rs
@@ -1,5 +1,4 @@
 use kube::CustomResource;
-use kube::Resource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/crds/src/lib.rs
+++ b/crds/src/lib.rs
@@ -3,12 +3,14 @@ use kube::Resource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(CustomResource,Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[kube(group = "confidential-containers.io", 
-    version = "v1alpha1", 
-    kind = "ConfidentialCluster", 
-    namespaced, 
-    plural = "confidentialclusters")]
+#[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[kube(
+    group = "confidential-containers.io",
+    version = "v1alpha1",
+    kind = "ConfidentialCluster",
+    namespaced,
+    plural = "confidentialclusters"
+)]
 pub struct ConfidentialClusterSpec {
     pub trustee: Trustee,
 }

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -23,7 +23,7 @@ use std::{
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Args {
+pub struct Args {
     /// Output directory to save rendered YAML
     #[arg(long, default_value = "manifests")]
     output_dir: PathBuf,

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -218,8 +218,7 @@ fn generate_operator(args: &Args) -> Result<()> {
     let trustee_role_yaml = serde_yaml::to_string(&trustee_role)?;
     let trustee_role_binding_yaml = serde_yaml::to_string(&trustee_role_binding)?;
 
-    let combined_yaml = format!(
-        "{}\n---\n{}\n---\n{}\n---\n{}\n---\n{}\n---\n{}\n---\n{}",
+    let combined_yaml = [
         ns_yaml,
         operator_yaml,
         sa_yaml,
@@ -227,7 +226,8 @@ fn generate_operator(args: &Args) -> Result<()> {
         cluster_role_binding_yaml,
         trustee_role_yaml,
         trustee_role_binding_yaml,
-    );
+    ]
+    .join("\n---\n");
 
     fs::write(&output_path, combined_yaml)?;
 

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -40,7 +40,7 @@ pub struct Args {
     namespace: String,
 
     /// Trustee namespace where to install trustee configuration
-    #[arg(long, default_value = "trustee")]
+    #[arg(long, default_value = "operators")]
     trustee_namespace: String,
 }
 

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -81,9 +81,7 @@ fn generate_operator(args: &Args) -> Result<()> {
                     containers: vec![Container {
                         name: name.to_string(),
                         image: Some(args.image.clone()),
-                        command: Some(vec![
-                            "/usr/bin/operator".to_string(),
-                        ]),
+                        command: Some(vec!["/usr/bin/operator".to_string()]),
                         ..Default::default()
                     }],
                     ..Default::default()
@@ -228,7 +226,7 @@ fn generate_operator(args: &Args) -> Result<()> {
         cluster_role_yaml,
         cluster_role_binding_yaml,
         trustee_role_yaml,
-        trustee_role_binding_yaml
+        trustee_role_binding_yaml,
     );
 
     fs::write(&output_path, combined_yaml)?;

--- a/operator/src/kbs-config.toml
+++ b/operator/src/kbs-config.toml
@@ -1,8 +1,6 @@
 [http_server]
 sockets = ["0.0.0.0:8080"]
-insecure_http = false
-private_key = /etc/https-key/https.key
-certificate = /etc/https-cert/https.crt
+insecure_http = true
 
 [admin]
 insecure_api = true

--- a/operator/src/kbs-config.toml
+++ b/operator/src/kbs-config.toml
@@ -1,0 +1,40 @@
+[http_server]
+sockets = ["0.0.0.0:8080"]
+insecure_http = false
+private_key = /etc/https-key/https.key
+certificate = /etc/https-cert/https.crt
+
+[admin]
+insecure_api = true
+auth_public_key = "/etc/auth-secret/publicKey"
+
+[attestation_token]
+insecure_key = true
+attestation_token_type = "CoCo"
+
+[attestation_service]
+type = "coco_as_builtin"
+work_dir = "/opt/confidential-containers/attestation-service"
+policy_engine = "opa"
+
+[attestation_service.attestation_token_broker]
+type = "Ear"
+policy_dir = "/opt/confidential-containers/attestation-service/policies"
+
+[attestation_service.attestation_token_config]
+duration_min = 5
+
+[attestation_service.rvps_config]
+type = "BuiltIn"
+
+[attestation_service.rvps_config.storage]
+type = "LocalJson"
+file_path = "/opt/confidential-containers/rvps/reference-values/reference-values.json"
+
+[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"
+
+[policy_engine]
+policy_path = "/opt/confidential-containers/opa/policy.rego"

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use env_logger::Env;
 use futures_util::StreamExt;
 use kube::runtime::reflector::Lookup;
@@ -10,7 +10,7 @@ use kube::runtime::{
     controller::{Action, Controller},
     watcher,
 };
-use kube::{api::ListParams, Api, Client};
+use kube::{Api, Client, api::ListParams};
 
 use log::{error, info};
 use thiserror::Error;
@@ -146,14 +146,10 @@ async fn main() -> Result<()> {
     let context = Arc::new(ContextData {
         client: client.clone(),
     });
-    info!(
-        "Confidential clusters operator",
-    );
+    info!("Confidential clusters operator",);
     let cl = Api::<ConfidentialCluster>::all(client.clone());
 
-    tokio::spawn(install_trustee_configuration(
-        client.clone(),
-    ));
+    tokio::spawn(install_trustee_configuration(client.clone()));
     Controller::new(cl, watcher::Config::default())
         .run::<_, ContextData>(reconcile, error_policy, context)
         .for_each(|res| async move {

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use env_logger::Env;
 use futures_util::StreamExt;
 use kube::runtime::{
@@ -81,6 +81,11 @@ async fn install_trustee_configuration(client: Client) -> Result<()> {
             cocl.spec.trustee.kbs_configuration
         ),
         Err(e) => error!("Failed to create the KBS configuration configmap: {e}"),
+    }
+
+    match trustee::generate_kbs_https_certificate(client.clone(), &trustee_namespace).await {
+        Ok(_) => info!("Generated HTTPS certificates for the KBS"),
+        Err(e) => error!("Failed to create HTTPS certificates for the KBS: {e}"),
     }
 
     match trustee::generate_reference_values(

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -1,11 +1,9 @@
-use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, bail};
 use env_logger::Env;
 use futures_util::StreamExt;
-use kube::runtime::reflector::Lookup;
 use kube::runtime::{
     controller::{Action, Controller},
     watcher,
@@ -40,16 +38,16 @@ async fn list_confidential_clusters(client: Client) -> anyhow::Result<Confidenti
                 "Found ConfidentialCluster: {}",
                 item.metadata.name.as_deref().unwrap_or("<no name>"),
             );
-            return Ok(item.deref().clone());
+            return Ok(item.clone());
         }
         _ => bail!("too many confidential cluster resources defined in the namespace"),
     }
 }
 
-async fn reconcile(g: Arc<ConfidentialCluster>, _ctx: Arc<ContextData>) -> Result<Action, Error> {
+async fn reconcile(_g: Arc<ConfidentialCluster>, _ctx: Arc<ContextData>) -> Result<Action, Error> {
     Ok(Action::requeue(Duration::from_secs(300)))
 }
-fn error_policy(obj: Arc<ConfidentialCluster>, _error: &Error, _ctx: Arc<ContextData>) -> Action {
+fn error_policy(_obj: Arc<ConfidentialCluster>, _error: &Error, _ctx: Arc<ContextData>) -> Action {
     Action::requeue(Duration::from_secs(60))
 }
 

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -59,47 +59,7 @@ pub async fn generate_kbs_configuration(
     namespace: &str,
     name: &str,
 ) -> anyhow::Result<()> {
-    let kbs_config_toml = r#"[http_server]
-sockets = ["0.0.0.0:8080"]
-insecure_http = false
-private_key = "/etc/https-key/https.key"
-certificate = "/etc/https-cert/https.crt"
-
-[admin]
-insecure_api = true
-auth_public_key = "/etc/auth-secret/publicKey"
-
-[attestation_token]
-insecure_key = true
-attestation_token_type = "CoCo"
-
-[attestation_service]
-type = "coco_as_builtin"
-work_dir = "/opt/confidential-containers/attestation-service"
-policy_engine = "opa"
-
-[attestation_service.attestation_token_broker]
-type = "Ear"
-policy_dir = "/opt/confidential-containers/attestation-service/policies"
-
-[attestation_service.attestation_token_config]
-duration_min = 5
-
-[attestation_service.rvps_config]
-type = "BuiltIn"
-
-[attestation_service.rvps_config.storage]
-type = "LocalJson"
-file_path = "/opt/confidential-containers/rvps/reference-values/reference-values.json"
-
-[[plugins]]
-name = "resource"
-type = "LocalFs"
-dir_path = "/opt/confidential-containers/kbs/repository"
-
-[policy_engine]
-policy_path = "/opt/confidential-containers/opa/policy.rego"
-"#;
+    let kbs_config_toml = include_str!("kbs-config.toml");
 
     let mut data = BTreeMap::new();
     data.insert("kbs-config.toml".to_string(), kbs_config_toml.to_string());

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose};
 use crds::{KbsConfig, KbsConfigSpec, Trustee};
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::api::PostParams;
 use kube::{Api, Client, Error};
 use log::info;
-use openssl::pkey::{PKey, Private};
+use openssl::pkey::PKey;
 use std::collections::BTreeMap;
 use std::fs;
 

--- a/scripts/install-trustee.sh
+++ b/scripts/install-trustee.sh
@@ -2,7 +2,7 @@
 
 OP_FRMWK_VERSION=0.31.0
 
-source ./common.sh
+source scripts/common.sh
 
 scripts/kubeconfig.sh
 export KUBECONFIG=$(pwd)/.kubeconfig

--- a/scripts/install-trustee.sh
+++ b/scripts/install-trustee.sh
@@ -12,21 +12,14 @@ curl -sL \
 	bash -s v${OP_FRMWK_VERSION}
 
 kubectl apply -f - << EOF
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: trustee
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
-metadata: 
-  name: trustee-operator
-  namespace: trustee
-spec: 
+metadata:
+  name: my-trustee-operator
+  namespace: operators
+spec:
   channel: alpha
   name: trustee-operator
   source: operatorhubio-catalog
   sourceNamespace: olm
 EOF
-
-kubectl create -f https://operatorhub.io/install/trustee-operator.yaml


### PR DESCRIPTION
- Few nits
- Use `operators` namespace until we resolve it (see issue below)
- Use insecure HTTP and dummy secrets until we resolve (see issue below)
- Add demo with HTTP KBS client to README

Probably review commit-by-commit for a better overview.