### PR TITLE
Compute PCRs, using labels and caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,12 +1150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "lo"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a010e03e6517e33f55f5fb5a49bf1cd367d54053648ea6fbf6f15aa68e0c62"
-
-[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1292,6 @@ dependencies = [
  "anyhow",
  "base64",
  "chrono",
- "clap",
  "crds",
  "env_logger",
  "futures-util",
@@ -1306,7 +1299,6 @@ dependencies = [
  "jsonptr",
  "k8s-openapi",
  "kube",
- "lo",
  "log",
  "openssl",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,22 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "aquamarine"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
+dependencies = [
+ "itertools 0.9.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -147,7 +160,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -155,6 +168,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "autocxx"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba64dd33efd8f09724143d45ab91b48aebcee52f4fb11add3464c998fab47dc"
+dependencies = [
+ "aquamarine",
+ "autocxx-macro",
+ "cxx",
+ "moveit",
+]
+
+[[package]]
+name = "autocxx-macro"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e594e68d030b6eb1ce7e2b40958f4f4ae7150c588c76d76b9f8178d41c47d80"
+dependencies = [
+ "autocxx-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "autocxx-parser"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef00b2fc378804c31c4fbd693a7fea93f8a90467dce331dae1e4ce41e542953"
+dependencies = [
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.104",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "backon"
@@ -179,14 +235,41 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -208,6 +291,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -276,7 +365,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -292,12 +381,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compute-pcrs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "compute-pcrs-lib",
+ "crds",
+ "k8s-openapi",
+ "kube",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "compute-pcrs-lib"
+version = "0.1.0"
+source = "git+https://github.com/confidential-clusters/compute-pcrs#4b73fffbd38c4a95ed2056487b4b674d42762756"
+dependencies = [
+ "anyhow",
+ "glob",
+ "hex",
+ "hex-literal",
+ "lief",
+ "openssl",
+ "serde",
+ "sha2",
+ "uuid",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -336,9 +476,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crds"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "compute-pcrs-lib",
  "k8s-openapi",
  "kube",
  "schemars",
@@ -363,6 +514,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c15f3b597018782655a05d417f28bac009f6eb60f4b6703eb818998c1aaa16a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7eb4c4fd18505f5a935f9c2ee77780350dcdb56da7cd037634e806141c5c43"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d914fcc6452d133236ee067a9538be25ba6a644a450e1a6c617da84bf029854"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -394,7 +574,47 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -414,7 +634,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -425,6 +645,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -442,7 +674,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -450,6 +682,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -468,7 +709,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -501,6 +742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +777,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -607,7 +868,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -674,10 +935,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -690,6 +989,31 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.10.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -708,10 +1032,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
- "http",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -723,7 +1047,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -731,6 +1055,33 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -754,6 +1105,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -764,13 +1126,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -781,8 +1163,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -800,6 +1182,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -807,8 +1213,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -826,15 +1232,29 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http",
- "hyper",
- "hyper-rustls",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -843,15 +1263,15 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -861,10 +1281,26 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -874,14 +1310,17 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
  "tokio",
@@ -914,10 +1353,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -926,7 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -935,16 +1492,67 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -973,7 +1581,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1022,12 +1630,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",
@@ -1052,25 +1675,25 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb276b85b6e94ded00ac8ea2c68fcf4697ea0553cb25fddc35d4a0ab718db8d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "either",
  "futures",
  "home",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-http-proxy",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls",
+ "rustls 0.23.29",
  "secrecy",
  "serde",
  "serde_json",
@@ -1092,7 +1715,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "form_urlencoded",
- "http",
+ "http 1.3.1",
  "json-patch",
  "k8s-openapi",
  "schemars",
@@ -1113,7 +1736,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1128,7 +1751,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown",
+ "hashbrown 0.15.4",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1144,10 +1767,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "lief"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c608b395ad9fe490b42bb7565ad3ff46c7ecc8cfba113542fc6dd3d15296e423"
+dependencies = [
+ "bitflags 2.9.1",
+ "cxx",
+ "lief-ffi",
+ "num-bigint",
+ "num-derive",
+ "num-traits",
+ "tempfile",
+]
+
+[[package]]
+name = "lief-build"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c5164f3ff46ec4719a37853314cd1f3f91736f9d15ea3ceb79e008219624ae4"
+dependencies = [
+ "git-version",
+ "miette",
+ "reqwest 0.11.24",
+ "semver",
+ "zip",
+]
+
+[[package]]
+name = "lief-ffi"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c86088f7d2a5aa868606323f0581b63a2b1ad3a70f815897a2ae9801e46f1fc"
+dependencies = [
+ "autocxx",
+ "cxx",
+ "lief-build",
+ "miette",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1186,6 +1876,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror 1.0.69",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1934,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "moveit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d7335204cb6ef7bd647fa6db0be3e4d7aa25b5823a7aa030027ddf512cefba"
+dependencies = [
+ "cxx",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +2011,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.3.1",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.12.23",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078e2f6be932a4de9aca90a375a45590809dfb5a08d93ab1ee217107aceeb67"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1247,7 +2085,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1264,7 +2102,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1290,8 +2128,9 @@ name = "operator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "chrono",
+ "compute-pcrs-lib",
  "crds",
  "env_logger",
  "futures-util",
@@ -1300,6 +2139,8 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "log",
+ "oci-client",
+ "oci-spec",
  "openssl",
  "serde",
  "serde_json",
@@ -1315,6 +2156,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"
@@ -1342,7 +2189,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1351,7 +2198,7 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -1392,7 +2239,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1422,7 +2269,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1459,6 +2306,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +2396,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1521,6 +2429,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +2529,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,7 +2563,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -1562,7 +2575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -1582,6 +2595,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
@@ -1596,6 +2618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1651,7 +2683,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1659,6 +2691,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secrecy"
@@ -1675,7 +2717,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1688,7 +2730,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1704,6 +2746,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -1732,7 +2780,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1743,7 +2791,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1759,12 +2807,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -1821,6 +2881,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,16 +2907,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1865,9 +2994,84 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -1895,7 +3099,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1906,8 +3110,52 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1936,7 +3184,27 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -1945,7 +3213,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -1972,7 +3240,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -1986,13 +3254,16 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.9.1",
  "bytes",
- "http",
- "http-body",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
  "mime",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2030,7 +3301,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2061,10 +3332,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2079,10 +3383,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2142,8 +3473,21 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2164,7 +3508,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2177,6 +3521,57 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2199,7 +3594,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2210,7 +3605,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2239,11 +3634,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2252,7 +3656,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2261,15 +3680,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2279,9 +3704,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2297,9 +3734,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2309,9 +3758,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2320,12 +3781,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
 ]
 
 [[package]]
@@ -2345,7 +3846,28 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
 ]
 
 [[package]]
@@ -2353,3 +3875,49 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "time",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,19 @@
 [workspace]
-members = ["crds", "operator", "manifest-gen"]
+members = ["compute-pcrs", "crds", "operator", "manifest-gen"]
 resolver = "3"
 
 [workspace.package]
 edition = "2024"
 
 [workspace.dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.99"
+chrono = "0.4.41"
+compute-pcrs-lib = { git = "https://github.com/confidential-clusters/compute-pcrs" }
 env_logger = "0.11.8"
+clap = "4.5.41"
 k8s-openapi = "0.25.0"
 kube = "1.1.0"
 log = "0.4.27"
 serde = "1.0.219"
 serde_json = "1.0.141"
+tokio = "1.46.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,15 @@
 [workspace]
 members = ["crds", "operator", "manifest-gen"]
 resolver = "3"
+
+[workspace.package]
+edition = "2024"
+
+[workspace.dependencies]
+anyhow = "1.0.98"
+env_logger = "0.11.8"
+k8s-openapi = "0.25.0"
+kube = "1.1.0"
+log = "0.4.27"
+serde = "1.0.219"
+serde_json = "1.0.141"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ KUBECTL=kubectl
 
 REGISTRY ?= quay.io
 OPERATOR_IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
+COMPUTE_PCRS_IMAGE=$(REGISTRY)/confidential-clusters/compute-pcrs:latest
 
 all: build tools
 
@@ -18,7 +19,8 @@ manifests-dir:
 manifests: tools
 	target/debug/manifest-gen --output-dir manifests \
 		--image $(OPERATOR_IMAGE) \
-		--trustee-namespace operators
+		--trustee-namespace operators \
+		--pcrs-compute-image $(COMPUTE_PCRS_IMAGE)
 
 cluster-up:
 	scripts/create-cluster-kind.sh
@@ -28,16 +30,20 @@ cluster-down:
 
 image: build
 	podman build -t $(OPERATOR_IMAGE) -f Containerfile .
+	podman build -t $(COMPUTE_PCRS_IMAGE) \
+		-f compute-pcrs/Containerfile \
+		--env K8S_OPENAPI_ENABLED_VERSION=$(K8S_VERSION) .
 
 # TODO: remove the tls-verify, right now we are pushing only on the local registry
 push: image
 	podman push $(OPERATOR_IMAGE) --tls-verify=false
+	podman push $(COMPUTE_PCRS_IMAGE) --tls-verify=false
 
 install-trustee:
 	scripts/install-trustee.sh
 
 install:
-	scripts/clean-cluster-kind.sh $(OPERATOR_IMAGE)
+	scripts/clean-cluster-kind.sh $(OPERATOR_IMAGE) $(COMPUTE_PCRS_IMAGE)
 	$(KUBECTL) apply -f manifests/operator.yaml
 	$(KUBECTL) apply -f manifests/confidential_cluster_crd.yaml
 	$(KUBECTL) apply -f manifests/confidential_cluster_cr.yaml

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ K8S_VERSION ?= 1.33
 KUBECTL=kubectl
 
 REGISTRY ?= quay.io
-IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
+OPERATOR_IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
 
 all: build tools
 
@@ -17,7 +17,7 @@ manifests-dir:
 
 manifests: tools
 	target/debug/manifest-gen --output-dir manifests \
-		--image $(IMAGE) \
+		--image $(OPERATOR_IMAGE) \
 		--trustee-namespace operators
 
 cluster-up:
@@ -27,17 +27,17 @@ cluster-down:
 	scripts/delete-cluster-kind.sh
 
 image: build
-	podman build -t $(IMAGE) -f Containerfile .
+	podman build -t $(OPERATOR_IMAGE) -f Containerfile .
 
 # TODO: remove the tls-verify, right now we are pushing only on the local registry
 push: image
-	podman push $(IMAGE) --tls-verify=false
+	podman push $(OPERATOR_IMAGE) --tls-verify=false
 
 install-trustee:
 	scripts/install-trustee.sh
 
 install:
-	scripts/clean-cluster-kind.sh $(IMAGE)
+	scripts/clean-cluster-kind.sh $(OPERATOR_IMAGE)
 	$(KUBECTL) apply -f manifests/operator.yaml
 	$(KUBECTL) apply -f manifests/confidential_cluster_crd.yaml
 	$(KUBECTL) apply -f manifests/confidential_cluster_cr.yaml

--- a/README.md
+++ b/README.md
@@ -27,29 +27,6 @@ within the cluster.
 
 ### Quick Start
 
-Fill the file `operator/src/reference-values-in.json` with the desired PCR values, e.g. by
-
-```bash
-$ for i in {4,7,14}; do
-    sudo tpm2_pcrread sha256:${i} | awk -F: '/0x/ {sub(/.*0x/, "", $2); gsub(/[^0-9A-Fa-f]/, "", $2); print tolower($2)}'
-done
-6401162a80170f039aabff2606d2c7b4843c592edcdc082abd66f644131d83c8
-b3a56a06c03a65277d0a787fcabc1e293eaa5d6dd79398f2dda741f7b874c65d
-17cdefd9548f4383b67a37a901673bf3c8ded6f619d36c8007562de1d93c81cc
-```
-
-i.e.
-
-```json
-{
-    "pcr4":  "6401162a80170f039aabff2606d2c7b4843c592edcdc082abd66f644131d83c8",
-    "pcr7":  "b3a56a06c03a65277d0a787fcabc1e293eaa5d6dd79398f2dda741f7b874c65d",
-    "pcr14": "17cdefd9548f4383b67a37a901673bf3c8ded6f619d36c8007562de1d93c81cc"
-}
-```
-
-> Hint: You can stop tracking changes to this file with `git update-index --skip-worktree operator/src/reference-values-in.json`.
-
 Create the cluster, install [trustee operator](https://github.com/confidential-containers/trustee-operator) and deploy 
 the operator.
 

--- a/compute-pcrs/Cargo.toml
+++ b/compute-pcrs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "compute-pcrs"
+version = "0.1.0"
+edition.workspace = true
+description = "A cocl-operator optimized compute-pcrs interface"
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+clap = { workspace = true, features = ["derive"] }
+crds = { path = "../crds" }
+compute-pcrs-lib.workspace = true
+k8s-openapi.workspace =true
+kube.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/confidential-clusters/compute-pcrs/buildroot AS builder
+WORKDIR /compute-pcrs
+COPY Cargo.toml Cargo.lock .
+COPY compute-pcrs compute-pcrs
+COPY crds crds
+# Hack: Set required crates as only members to avoid needing to copy other crates.
+# In that case, a rebuild would be triggered upon any change in those crates.
+RUN sed -i 's/members =.*/members = ["crds", "compute-pcrs"]/' Cargo.toml && \
+    git clone --depth 1 https://github.com/confidential-clusters/reference-values && \
+    cargo build --release -p compute-pcrs
+
+FROM quay.io/fedora/fedora:42
+COPY --from=builder /compute-pcrs/target/release/compute-pcrs /usr/local/bin
+COPY --from=builder /compute-pcrs/reference-values /reference-values

--- a/compute-pcrs/src/main.rs
+++ b/compute-pcrs/src/main.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+use clap::Parser;
+use compute_pcrs_lib::*;
+use crds::{ImagePcr, ImagePcrs, PCR_CONFIG_FILE, PCR_CONFIG_MAP};
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::{Api, Client, api::PostParams};
+use std::collections::BTreeMap;
+
+#[derive(Parser)]
+#[command(version, about)]
+struct Args {
+    /// Path to the kernel modules directory
+    #[arg(short, long)]
+    kernels: String,
+    /// Path to the ESP directory
+    #[arg(short, long)]
+    esp: String,
+    /// Path to the directory storing EFIVar files
+    #[arg(short = 's', long)]
+    efivars: String,
+    /// Path to directory storing MokListRT, MokListTrustedRT and MokListXRT
+    #[arg(short, long)]
+    mokvars: String,
+    /// Image reference
+    #[arg(short, long)]
+    image: String,
+    /// Namespace to write ConfigMap to
+    #[arg(short, long)]
+    namespace: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let pcrs = vec![
+        compute_pcr4(&args.kernels, &args.esp, false, true),
+        compute_pcr7(Some(&args.efivars), &args.esp, true),
+        compute_pcr14(&args.mokvars),
+    ];
+
+    let client = Client::try_default().await?;
+    let config_maps: Api<ConfigMap> = Api::namespaced(client, &args.namespace);
+
+    let mut image_pcrs_map = config_maps.get(PCR_CONFIG_MAP).await?;
+    let image_pcrs_data = image_pcrs_map
+        .data
+        .context("Image PCRs map existed, but had no data")?;
+    let image_pcrs_str = image_pcrs_data
+        .get(PCR_CONFIG_FILE)
+        .context("Image PCRs data existed, but had no file")?;
+    let mut image_pcrs: ImagePcrs = serde_json::from_str(image_pcrs_str)?;
+
+    let image_pcr = ImagePcr {
+        first_seen: Utc::now(),
+        pcrs,
+    };
+    image_pcrs.pcrs.insert(args.image, image_pcr);
+
+    let image_pcrs_json = serde_json::to_string(&image_pcrs)?;
+    let data = BTreeMap::from([(PCR_CONFIG_FILE.to_string(), image_pcrs_json.to_string())]);
+    image_pcrs_map.data = Some(data);
+    config_maps
+        .replace(PCR_CONFIG_MAP, &PostParams::default(), &image_pcrs_map)
+        .await?;
+    Ok(())
+}

--- a/crds/Cargo.toml
+++ b/crds/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "crds"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
-k8s-openapi = "0.25.0"
-kube = { version = "1.1.0", features = ["derive"] }
+k8s-openapi.workspace = true
+kube = { workspace = true, features = ["derive"] }
 schemars = { version = "0.8", features = ["derive"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.141"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/crds/Cargo.toml
+++ b/crds/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+chrono.workspace = true
+compute-pcrs-lib.workspace = true
 k8s-openapi.workspace = true
 kube = { workspace = true, features = ["derive"] }
 schemars = { version = "0.8", features = ["derive"] }

--- a/crds/src/lib.rs
+++ b/crds/src/lib.rs
@@ -1,6 +1,9 @@
+use chrono::{DateTime, Utc};
+use compute_pcrs_lib::Pcr;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[kube(
@@ -10,8 +13,24 @@ use serde::{Deserialize, Serialize};
     namespaced,
     plural = "confidentialclusters"
 )]
+#[serde(rename_all = "camelCase")]
 pub struct ConfidentialClusterSpec {
     pub trustee: Trustee,
+    pub pcrs_compute_image: String,
+}
+
+pub const PCR_CONFIG_MAP: &str = "image-pcrs";
+pub const PCR_CONFIG_FILE: &str = "image-pcrs.json";
+
+#[derive(Deserialize, Serialize)]
+pub struct ImagePcr {
+    pub first_seen: DateTime<Utc>,
+    pub pcrs: Vec<Pcr>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ImagePcrs {
+    pub pcrs: BTreeMap<String, ImagePcr>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/kind/config.yaml
+++ b/kind/config.yaml
@@ -9,3 +9,5 @@ nodes:
   extraPortMappings:
   - containerPort: 31000
     hostPort: 8080
+featureGates:
+  "ImageVolume": true

--- a/manifest-gen/Cargo.toml
+++ b/manifest-gen/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 env_logger.workspace = true
-clap = { version = "4.5.41", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 crds = { path = "../crds" }
 k8s-openapi.workspace = true
 kube = { workspace = true, features = ["derive"] }

--- a/manifest-gen/Cargo.toml
+++ b/manifest-gen/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "manifest-gen"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
-crds = { path = "../crds" }
-anyhow = "1.0.98"
+anyhow.workspace = true
+env_logger.workspace = true
 clap = { version = "4.5.41", features = ["derive"] }
-kube = { version = "1.1.0", features = ["derive"] }
+crds = { path = "../crds" }
+k8s-openapi.workspace = true
+kube = { workspace = true, features = ["derive"] }
+log.workspace = true
 serde_yaml = "0.9"
-k8s-openapi = "0.25.0"
-log = "0.4.27"
-env_logger = "0.11.8"

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -113,7 +113,7 @@ fn generate_operator(args: &Args) -> Result<()> {
 
     let cluster_role = ClusterRole {
         metadata: ObjectMeta {
-            name: Some(format!("{}-role", service_account_name)),
+            name: Some(format!("{service_account_name}-role")),
             ..Default::default()
         },
         rules: Some(vec![
@@ -142,13 +142,13 @@ fn generate_operator(args: &Args) -> Result<()> {
 
     let cluster_role_binding = ClusterRoleBinding {
         metadata: ObjectMeta {
-            name: Some(format!("{}-rolebinding", service_account_name)),
+            name: Some(format!("{service_account_name}-rolebinding")),
             ..Default::default()
         },
         role_ref: RoleRef {
             api_group: "rbac.authorization.k8s.io".to_string(),
             kind: "ClusterRole".to_string(),
-            name: format!("{}-role", service_account_name),
+            name: format!("{service_account_name}-role"),
         },
         subjects: Some(vec![Subject {
             kind: "ServiceAccount".to_string(),

--- a/manifest-gen/src/main.rs
+++ b/manifest-gen/src/main.rs
@@ -4,10 +4,9 @@ use crds::{ConfidentialCluster, ConfidentialClusterSpec, Trustee};
 use k8s_openapi::{
     api::{
         apps::v1::Deployment,
-        core::v1::{Container, Namespace, PodSpec, PodTemplateSpec, ServiceAccount},
-        rbac::v1::{
-            PolicyRule, Role, RoleBinding, RoleRef, Subject,
-        },
+        batch::v1::Job,
+        core::v1::{ConfigMap, Container, Namespace, PodSpec, PodTemplateSpec, ServiceAccount},
+        rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject},
     },
     apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta},
 };
@@ -42,6 +41,12 @@ pub struct Args {
     /// Trustee namespace where to install trustee configuration
     #[arg(long, default_value = "operators")]
     trustee_namespace: String,
+
+    #[arg(
+        long,
+        default_value = "quay.io/confidential-clusters/compute-pcrs:latest"
+    )]
+    pcrs_compute_image: String,
 }
 
 fn generate_operator(args: &Args) -> Result<()> {
@@ -99,12 +104,12 @@ fn generate_operator(args: &Args) -> Result<()> {
     let output_path = args.output_dir.join("operator.yaml");
 
     // RBAC
-    let service_account_name = "cocl-operator";
+    let operator_service_account_name = "cocl-operator";
     let namespace = args.namespace.to_string();
 
-    let sa = ServiceAccount {
+    let operator_service_account = ServiceAccount {
         metadata: ObjectMeta {
-            name: Some(service_account_name.to_string()),
+            name: Some(operator_service_account_name.to_string()),
             namespace: Some(namespace.clone()),
             ..Default::default()
         },
@@ -113,11 +118,37 @@ fn generate_operator(args: &Args) -> Result<()> {
 
     let operator_role = Role {
         metadata: ObjectMeta {
-            name: Some(format!("{service_account_name}-role")),
+            name: Some(format!("{operator_service_account_name}-role")),
             namespace: Some(namespace.clone()),
             ..Default::default()
         },
         rules: Some(vec![
+            PolicyRule {
+                api_groups: Some(vec!["batch".to_string()]),
+                resources: Some(vec![Job::plural(&()).to_string()]),
+                verbs: vec![
+                    "create".to_string(),
+                    "get".to_string(),
+                    "list".to_string(),
+                    "watch".to_string(),
+                    "patch".to_string(),
+                    "update".to_string(),
+                ],
+                ..Default::default()
+            },
+            PolicyRule {
+                api_groups: Some(vec!["".to_string()]),
+                resources: Some(vec![ConfigMap::plural(&()).to_string()]),
+                verbs: vec![
+                    "create".to_string(),
+                    "get".to_string(),
+                    "list".to_string(),
+                    "watch".to_string(),
+                    "patch".to_string(),
+                    "update".to_string(),
+                ],
+                ..Default::default()
+            },
             PolicyRule {
                 api_groups: Some(vec![ConfidentialCluster::group(&()).to_string()]),
                 resources: Some(vec![ConfidentialCluster::plural(&()).to_string()]),
@@ -138,23 +169,73 @@ fn generate_operator(args: &Args) -> Result<()> {
                 ..Default::default()
             },
         ]),
-        ..Default::default()
     };
 
     let operator_role_binding = RoleBinding {
         metadata: ObjectMeta {
-            name: Some(format!("{service_account_name}-rolebinding")),
+            name: Some(format!("{operator_service_account_name}-rolebinding")),
             namespace: Some(namespace.clone()),
             ..Default::default()
         },
         role_ref: RoleRef {
             api_group: "rbac.authorization.k8s.io".to_string(),
             kind: "Role".to_string(),
-            name: format!("{service_account_name}-role"),
+            name: format!("{operator_service_account_name}-role"),
         },
         subjects: Some(vec![Subject {
             kind: "ServiceAccount".to_string(),
-            name: service_account_name.to_string(),
+            name: operator_service_account_name.to_string(),
+            namespace: Some(namespace.clone()),
+            ..Default::default()
+        }]),
+    };
+
+    let compute_pcrs_service_account_name = "compute-pcrs";
+
+    let compute_pcrs_service_account = ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(compute_pcrs_service_account_name.to_string()),
+            namespace: Some(namespace.clone()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let compute_pcrs_role = Role {
+        metadata: ObjectMeta {
+            name: Some(format!("{compute_pcrs_service_account_name}-role")),
+            namespace: Some(namespace.clone()),
+            ..Default::default()
+        },
+        rules: Some(vec![PolicyRule {
+            api_groups: Some(vec!["".to_string()]),
+            resources: Some(vec![ConfigMap::plural(&()).to_string()]),
+            verbs: vec![
+                "create".to_string(),
+                "get".to_string(),
+                "list".to_string(),
+                "watch".to_string(),
+                "patch".to_string(),
+                "update".to_string(),
+            ],
+            ..Default::default()
+        }]),
+    };
+
+    let compute_pcrs_role_binding = RoleBinding {
+        metadata: ObjectMeta {
+            name: Some(format!("{compute_pcrs_service_account_name}-rolebinding")),
+            namespace: Some(namespace.clone()),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "Role".to_string(),
+            name: format!("{compute_pcrs_service_account_name}-role"),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: compute_pcrs_service_account_name.to_string(),
             namespace: Some(namespace.clone()),
             ..Default::default()
         }]),
@@ -208,24 +289,30 @@ fn generate_operator(args: &Args) -> Result<()> {
         },
         subjects: Some(vec![Subject {
             kind: "ServiceAccount".to_string(),
-            name: service_account_name.to_string(),
+            name: operator_service_account_name.to_string(),
             namespace: Some(namespace),
             ..Default::default()
         }]),
     };
 
-    let sa_yaml = serde_yaml::to_string(&sa)?;
+    let operator_service_account_yaml = serde_yaml::to_string(&operator_service_account)?;
     let operator_role_yaml = serde_yaml::to_string(&operator_role)?;
     let operator_role_binding_yaml = serde_yaml::to_string(&operator_role_binding)?;
+    let compute_pcrs_service_account_yaml = serde_yaml::to_string(&compute_pcrs_service_account)?;
+    let compute_pcrs_role_yaml = serde_yaml::to_string(&compute_pcrs_role)?;
+    let compute_pcrs_role_binding_yaml = serde_yaml::to_string(&compute_pcrs_role_binding)?;
     let trustee_role_yaml = serde_yaml::to_string(&trustee_role)?;
     let trustee_role_binding_yaml = serde_yaml::to_string(&trustee_role_binding)?;
 
     let combined_yaml = [
         ns_yaml,
         operator_yaml,
-        sa_yaml,
+        operator_service_account_yaml,
         operator_role_yaml,
         operator_role_binding_yaml,
+        compute_pcrs_service_account_yaml,
+        compute_pcrs_role_yaml,
+        compute_pcrs_role_binding_yaml,
         trustee_role_yaml,
         trustee_role_binding_yaml,
     ]
@@ -273,6 +360,7 @@ pub fn generate_confidential_cluster_cr(args: &Args) -> Result<()> {
                 kbs_auth_key: "kbs-auth-key".to_string(),
                 kbs_config_name: "kbsconfig".to_string(),
             },
+            pcrs_compute_image: args.pcrs_compute_image.clone(),
         },
     };
 

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -6,17 +6,20 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 base64 = "0.22.1"
-chrono = "0.4.41"
+chrono.workspace = true
+compute-pcrs-lib.workspace = true
 crds = { path = "../crds" }
-env_logger = { workspace = true }
+env_logger.workspace = true
 futures-util = "0.3.31"
 json-patch = "4.0.0"
 jsonptr = "0.7.1"
 k8s-openapi.workspace = true
 kube = { workspace = true, features = ["runtime"] }
 log.workspace = true
+oci-spec = "0.8.2"
+oci-client = "0.15.0"
 openssl = "0.10.73"
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,25 +1,22 @@
 [package]
 name = "operator"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 
 [dependencies]
-clap = { version = "4.5.41", features = ["derive"] }
-crds = { path = "../crds" }
-env_logger = "0.11.8"
-
-futures-util = "0.3.31"
-kube = { version = "1.1.0", features = ["runtime"] }
-lo = "0.0.1"
-log = "0.4.27"
-thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = "0.25.0"
-openssl = "0.10.73"
+anyhow.workspace = true
 base64 = "0.22.1"
-anyhow = "1.0.98"
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.141"
 chrono = "0.4.41"
+crds = { path = "../crds" }
+env_logger = { workspace = true }
+futures-util = "0.3.31"
 json-patch = "4.0.0"
 jsonptr = "0.7.1"
+k8s-openapi.workspace = true
+kube = { workspace = true, features = ["runtime"] }
+log.workspace = true
+openssl = "0.10.73"
+thiserror = "2.0.12"
+tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/operator/src/macros.rs
+++ b/operator/src/macros.rs
@@ -1,0 +1,13 @@
+macro_rules! info_if_exists {
+    ($result:ident, $resource_type:literal, $resource_name:expr) => {
+        match $result {
+            Ok(_) => info!("Create {} {}", $resource_type, $resource_name),
+            Err(kube::Error::Api(ae)) if ae.code == 409 => {
+                info!("{} {} already exists", $resource_type, $resource_name)
+            }
+            Err(e) => return Err(e.into()),
+        }
+    };
+}
+
+pub(crate) use info_if_exists;

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -26,8 +26,10 @@ struct ContextData {
     client: Client,
 }
 
-async fn list_confidential_clusters(client: Client) -> anyhow::Result<ConfidentialCluster> {
-    let namespace = client.default_namespace();
+async fn list_confidential_clusters(
+    client: Client,
+    namespace: &str,
+) -> anyhow::Result<ConfidentialCluster> {
     info!("Listing ConfidentialClusters in namespace '{namespace}'");
     let api: Api<ConfidentialCluster> = Api::namespaced(client.clone(), namespace);
     let lp = ListParams::default();
@@ -53,8 +55,8 @@ fn error_policy(_obj: Arc<ConfidentialCluster>, _error: &Error, _ctx: Arc<Contex
     Action::requeue(Duration::from_secs(60))
 }
 
-async fn install_trustee_configuration(client: Client) -> Result<()> {
-    let cocl = list_confidential_clusters(client.clone()).await?;
+async fn install_trustee_configuration(client: Client, namespace: String) -> Result<()> {
+    let cocl = list_confidential_clusters(client.clone(), &namespace).await?;
     let trustee_namespace = cocl.spec.trustee.namespace.clone();
 
     match trustee::generate_kbs_auth_public_key(
@@ -162,13 +164,14 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let client = Client::try_default().await?;
+    let namespace = client.clone().default_namespace().to_string();
     let context = Arc::new(ContextData {
         client: client.clone(),
     });
     info!("Confidential clusters operator",);
-    let cl = Api::<ConfidentialCluster>::all(client.clone());
+    let cl = Api::<ConfidentialCluster>::namespaced(client.clone(), &namespace);
 
-    tokio::spawn(install_trustee_configuration(client.clone()));
+    tokio::spawn(install_trustee_configuration(client.clone(), namespace));
     Controller::new(cl, watcher::Config::default())
         .run::<_, ContextData>(reconcile, error_policy, context)
         .for_each(|res| async move {

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -26,6 +26,8 @@ struct ContextData {
     client: Client,
 }
 
+const BOOT_IMAGE: &str = "quay.io/fedora/fedora-coreos:42.20250705.3.0";
+
 async fn list_confidential_clusters(
     client: Client,
     namespace: &str,
@@ -92,7 +94,11 @@ async fn install_trustee_configuration(client: Client, namespace: String) -> Res
         Err(e) => error!("Failed to create HTTPS certificates for the KBS: {e}"),
     }
 
-    match trustee::generate_reference_values(
+    match reference_values::create_pcrs_config_map(client.clone(), &namespace).await {
+        Ok(_) => info!("Created bare configmap for PCRs"),
+        Err(e) => info!("Failed to create the PCRs configmap: {e}"),
+    }
+    match trustee::create_reference_value_config_map(
         client.clone(),
         &trustee_namespace,
         &cocl.spec.trustee.reference_values,
@@ -100,10 +106,38 @@ async fn install_trustee_configuration(client: Client, namespace: String) -> Res
     .await
     {
         Ok(_) => info!(
-            "Generate configmap for the reference values: {}",
+            "Created bare configmap for the reference values: {}",
             cocl.spec.trustee.reference_values
         ),
         Err(e) => error!("Failed to create the reference values configmap: {e}"),
+    }
+    // TODO CVO input
+    match reference_values::handle_new_image(
+        client.clone(),
+        &namespace,
+        BOOT_IMAGE,
+        &cocl.spec.pcrs_compute_image,
+    )
+    .await
+    {
+        Ok(_) => info!("Computed or retrieved reference values for image: {BOOT_IMAGE}",),
+        Err(e) => {
+            error!("Failed to compute or retrieve reference values for image {BOOT_IMAGE}: {e}",)
+        }
+    }
+    match trustee::recompute_reference_values(
+        client.clone(),
+        &namespace,
+        &trustee_namespace,
+        &cocl.spec.trustee.reference_values,
+    )
+    .await
+    {
+        Ok(_) => info!(
+            "Recomputed reference values to configmap: {}",
+            cocl.spec.trustee.reference_values
+        ),
+        Err(e) => error!("Failed to recompute reference values: {e}"),
     }
 
     match trustee::generate_resource_policy(

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -14,6 +14,7 @@ use log::{error, info};
 use thiserror::Error;
 
 use crds::ConfidentialCluster;
+mod macros;
 mod reference_values;
 mod trustee;
 

--- a/operator/src/reference-values-in.json
+++ b/operator/src/reference-values-in.json
@@ -1,5 +1,0 @@
-{
-    "pcr4":  "fill in your expected PCR value here",
-    "pcr7":  "fill in your expected PCR value here",
-    "pcr14": "fill in your expected PCR value here"
-}

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -1,22 +1,217 @@
-use chrono::{DateTime, Utc};
-use serde::{Serialize, Serializer};
+use anyhow::Context;
+use chrono::Utc;
+use compute_pcrs_lib::Pcr;
+use crds::{ImagePcr, ImagePcrs, PCR_CONFIG_FILE, PCR_CONFIG_MAP};
+use k8s_openapi::api::{
+    batch::v1::{Job, JobSpec},
+    core::v1::{
+        ConfigMap, ConfigMapVolumeSource, Container, ImageVolumeSource, KeyToPath, PodSpec,
+        PodTemplateSpec, Volume, VolumeMount,
+    },
+};
+use kube::api::{ObjectMeta, PostParams};
+use kube::runtime::wait::{await_condition, conditions::is_job_completed};
+use kube::{Api, Client};
+use log::info;
+use oci_client::secrets::RegistryAuth;
+use oci_spec::image::ImageConfiguration;
+use serde::Deserialize;
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
+use tokio::time::timeout;
 
-fn primitive_date_time_to_str<S>(d: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer
-{
-    s.serialize_str(&d.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+use crate::macros::info_if_exists;
+
+const PCR_COMMAND_NAME: &str = "compute-pcrs";
+const PCR_LABEL: &str = "org.coreos.pcrs";
+
+/// Synchronize with compute_pcrs_cli::Output
+#[derive(Deserialize)]
+struct ComputePcrsOutput {
+    pcrs: Vec<Pcr>,
 }
 
-/// Sync with Trustee
-/// reference_value_provider_service::reference_value::ReferenceValue
-/// (cannot import directly because its expiration doesn't serialize
-/// right)
-#[derive(Serialize)]
-pub struct ReferenceValue {
-    pub version: String,
-    pub name: String,
-    #[serde(serialize_with = "primitive_date_time_to_str")]
-    pub expiration: DateTime<Utc>,
-    pub value: serde_json::Value,
+pub async fn create_pcrs_config_map(client: Client, namespace: &str) -> anyhow::Result<()> {
+    let empty_data = BTreeMap::from([(PCR_CONFIG_FILE.to_string(), r#"{"pcrs": {}}"#.to_string())]);
+    let config_maps: Api<ConfigMap> = Api::namespaced(client, namespace);
+    let config_map = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(PCR_CONFIG_MAP.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        data: Some(empty_data),
+        ..Default::default()
+    };
+    let create = config_maps
+        .create(&PostParams::default(), &config_map)
+        .await;
+    info_if_exists!(create, "ConfigMap", PCR_CONFIG_MAP);
+
+    Ok(())
+}
+
+pub fn get_image_pcrs(image_pcrs_map: ConfigMap) -> anyhow::Result<ImagePcrs> {
+    let image_pcrs_data = image_pcrs_map
+        .data
+        .context("Image PCRs map existed, but had no data")?;
+    let image_pcrs_str = image_pcrs_data
+        .get(PCR_CONFIG_FILE)
+        .context("Image PCRs data existed, but had no file")?;
+    serde_json::from_str(image_pcrs_str).map_err(Into::into)
+}
+
+async fn fetch_pcr_label(image_ref: &str) -> anyhow::Result<Option<Vec<Pcr>>> {
+    let reference: oci_client::Reference = image_ref.parse()?;
+    let client = oci_client::Client::new(Default::default());
+    let (_, _, raw_config) = client
+        .pull_manifest_and_config(&reference, &RegistryAuth::Anonymous)
+        .await?;
+    let config: ImageConfiguration = serde_json::from_str(&raw_config)?;
+    config
+        .labels_of_config()
+        .and_then(|m| m.get(PCR_LABEL))
+        .map(|l| serde_json::from_str::<ComputePcrsOutput>(l).map(|o| o.pcrs))
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn build_compute_pcrs_pod_spec(
+    namespace: &str,
+    boot_image: &str,
+    pcrs_compute_image: &str,
+) -> PodSpec {
+    let image_volume_name = "image";
+    let image_mountpoint = PathBuf::from(format!("/{image_volume_name}"));
+    let pcrs_volume_name = "pcrs";
+    let pcrs_mountpoint = PathBuf::from(format!("/{pcrs_volume_name}"));
+
+    let mut cmd = vec![PCR_COMMAND_NAME.to_string()];
+    let mut add_flag = |flag: &str, value: &str| {
+        cmd.push(format!("--{flag}"));
+        cmd.push(value.to_string());
+    };
+    for (flag, path_suffix) in [
+        ("kernels", "usr/lib/modules"),
+        ("esp", "usr/lib/bootupd/updates"),
+    ] {
+        let full_path = image_mountpoint.clone().join(path_suffix);
+        add_flag(flag, full_path.to_str().unwrap());
+    }
+    for (flag, value) in [
+        ("efivars", "/reference-values/efivars/qemu-ovmf/fcos-42"),
+        ("mokvars", "/reference-values/mok-variables/fcos-42"),
+        ("image", boot_image),
+        ("namespace", namespace),
+    ] {
+        add_flag(flag, value);
+    }
+
+    PodSpec {
+        service_account_name: Some("compute-pcrs".to_string()),
+        containers: vec![Container {
+            name: PCR_COMMAND_NAME.to_string(),
+            image: Some(pcrs_compute_image.to_string()),
+            command: Some(cmd),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    name: image_volume_name.to_string(),
+                    mount_path: image_mountpoint.to_str().unwrap().to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    name: pcrs_volume_name.to_string(),
+                    mount_path: pcrs_mountpoint.to_str().unwrap().to_string(),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        }],
+        volumes: Some(vec![
+            Volume {
+                name: image_volume_name.to_string(),
+                image: Some(ImageVolumeSource {
+                    reference: Some(boot_image.to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            Volume {
+                name: pcrs_volume_name.to_string(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: PCR_CONFIG_MAP.to_string(),
+                    items: Some(vec![KeyToPath {
+                        key: PCR_CONFIG_FILE.to_string(),
+                        path: PCR_CONFIG_FILE.to_string(),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ]),
+        restart_policy: Some("Never".to_string()),
+        ..Default::default()
+    }
+}
+
+async fn compute_fresh_pcrs(
+    client: Client,
+    namespace: &str,
+    boot_image: &str,
+    pcrs_compute_image: &str,
+) -> anyhow::Result<()> {
+    let pod_spec = build_compute_pcrs_pod_spec(namespace, boot_image, pcrs_compute_image);
+    let job = Job {
+        metadata: ObjectMeta {
+            name: Some(PCR_COMMAND_NAME.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            template: PodTemplateSpec {
+                spec: Some(pod_spec),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let jobs: Api<Job> = Api::namespaced(client.clone(), namespace);
+    let create = jobs.create(&PostParams::default(), &job).await;
+    info_if_exists!(create, "Job", PCR_COMMAND_NAME);
+    let completed = await_condition(jobs, PCR_COMMAND_NAME, is_job_completed());
+    let _ = timeout(Duration::from_secs(900), completed).await?;
+    Ok(())
+}
+
+pub async fn handle_new_image(
+    client: Client,
+    namespace: &str,
+    boot_image: &str,
+    pcrs_compute_image: &str,
+) -> anyhow::Result<()> {
+    let config_maps: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    let mut image_pcrs_map = config_maps.get(PCR_CONFIG_MAP).await?;
+    let mut image_pcrs = get_image_pcrs(image_pcrs_map.clone())?;
+    if image_pcrs.pcrs.contains_key(boot_image) {
+        return Ok(());
+    }
+    let label = fetch_pcr_label(boot_image).await?;
+    if label.is_none() {
+        return compute_fresh_pcrs(client, namespace, boot_image, pcrs_compute_image).await;
+    }
+
+    let image_pcr = ImagePcr {
+        first_seen: Utc::now(),
+        pcrs: label.unwrap(),
+    };
+    image_pcrs.pcrs.insert(boot_image.to_string(), image_pcr);
+    let image_pcrs_json = serde_json::to_string(&image_pcrs)?;
+    let data = BTreeMap::from([(PCR_CONFIG_FILE.to_string(), image_pcrs_json.to_string())]);
+    image_pcrs_map.data = Some(data);
+    config_maps
+        .replace(PCR_CONFIG_MAP, &PostParams::default(), &image_pcrs_map)
+        .await?;
+    Ok(())
 }

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -1,20 +1,41 @@
-use anyhow::anyhow;
 use base64::{Engine as _, engine::general_purpose};
-use crds::{KbsConfig, KbsConfigSpec, Trustee};
+use chrono::{DateTime, TimeDelta, Utc};
+use crds::{KbsConfig, KbsConfigSpec, PCR_CONFIG_MAP, Trustee};
 use json_patch::{AddOperation, PatchOperation, TestOperation};
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
-use kube::api::{Patch, PatchParams, PostParams};
+use kube::api::{ObjectMeta, Patch, PatchParams, PostParams};
 use kube::{Api, Client};
 use log::info;
 use openssl::pkey::PKey;
-use std::collections::BTreeMap;
-use std::fs;
+use serde::{Serialize, Serializer};
+use std::{collections::BTreeMap, fs};
 
-use crate::reference_values::ReferenceValue;
 use crate::macros::info_if_exists;
+use crate::reference_values::get_image_pcrs;
 
 const HTTPS_KEY: &str = "kbs-https-key";
 const HTTPS_CERT: &str = "kbs-https-certificate";
+const REFERENCE_VALUES_FILE: &str = "reference-values.json";
+
+fn primitive_date_time_to_str<S>(d: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_str(&d.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
+/// Sync with Trustee
+/// reference_value_provider_service::reference_value::ReferenceValue
+/// (cannot import directly because its expiration doesn't serialize
+/// right)
+#[derive(Serialize)]
+struct ReferenceValue {
+    pub version: String,
+    pub name: String,
+    #[serde(serialize_with = "primitive_date_time_to_str")]
+    pub expiration: DateTime<Utc>,
+    pub value: serde_json::Value,
+}
 
 pub async fn generate_kbs_auth_public_key(
     client: Client,
@@ -114,58 +135,66 @@ pub async fn generate_kbs_configurations(
     Ok(())
 }
 
-pub async fn generate_reference_values(
+pub async fn recompute_reference_values(
+    client: Client,
+    operator_namespace: &str,
+    trustee_namespace: &str,
+    name: &str,
+) -> anyhow::Result<()> {
+    let operator_config_maps: Api<ConfigMap> = Api::namespaced(client.clone(), operator_namespace);
+    let image_pcrs_map = operator_config_maps.get(PCR_CONFIG_MAP).await?;
+    let image_pcrs = get_image_pcrs(image_pcrs_map)?;
+    // TODO many grub+shim:many OS image recompute once supported
+    let mut reference_values_in = BTreeMap::from([(
+        "svn".to_string(),
+        vec![serde_json::Value::String("1".to_string())],
+    )]);
+    for pcr in image_pcrs.pcrs.values().flat_map(|v| &v.pcrs) {
+        reference_values_in
+            .entry(format!("pcr{}", pcr.id))
+            .or_default()
+            .push(serde_json::Value::String(pcr.value.clone()));
+    }
+    let reference_values: Vec<_> = reference_values_in
+        .iter()
+        .map(|(name, values)| ReferenceValue {
+            version: "0.1.0".to_string(),
+            name: format!("tpm_{name}"),
+            expiration: Utc::now() + TimeDelta::days(365),
+            value: serde_json::Value::Array(values.to_vec()),
+        })
+        .collect();
+    let reference_values_json = serde_json::to_string(&reference_values)?;
+    let data = BTreeMap::from([(
+        REFERENCE_VALUES_FILE.to_string(),
+        reference_values_json.to_string(),
+    )]);
+
+    let trustee_config_maps: Api<ConfigMap> = Api::namespaced(client, trustee_namespace);
+    let mut rvs = trustee_config_maps.get(name).await?;
+    rvs.data = Some(data);
+    trustee_config_maps
+        .replace(name, &PostParams::default(), &rvs)
+        .await?;
+    Ok(())
+}
+
+pub async fn create_reference_value_config_map(
     client: Client,
     namespace: &str,
     name: &str,
 ) -> anyhow::Result<()> {
-    let reference_values_in_json = include_str!("reference-values-in.json");
-    let mut reference_values_in = match serde_json::from_str(reference_values_in_json)? {
-        serde_json::Value::Object(vals) => vals,
-        _ => return Err(anyhow!("Reference values had unexpected shape")),
-    };
-    reference_values_in.insert(
-        "svn".to_string(),
-        serde_json::Value::String("1".to_string()),
-    );
-    let reference_values = reference_values_in
-        .iter()
-        .map(|(name, value)| {
-            if let serde_json::Value::String(hex) = value
-                && hex
-                    .chars()
-                    .all(|c| (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))
-            {
-                Ok(ReferenceValue {
-                    version: "0.1.0".to_string(),
-                    name: format!("tpm_{name}"),
-                    expiration: chrono::DateTime::<chrono::Utc>::MAX_UTC,
-                    value: serde_json::Value::Array(vec![value.clone()]),
-                })
-            } else {
-                Err(anyhow!("Reference value '{value}' had unexpected shape"))
-            }
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let reference_values_json = serde_json::to_string(&reference_values)?;
-
-    let mut data = BTreeMap::new();
-    data.insert(
-        "reference-values.json".to_string(),
-        reference_values_json.to_string(),
-    );
-
+    let empty_data = BTreeMap::from([(REFERENCE_VALUES_FILE.to_string(), "{}".to_string())]);
+    let config_maps: Api<ConfigMap> = Api::namespaced(client, namespace);
     let config_map = ConfigMap {
-        metadata: kube::api::ObjectMeta {
+        metadata: ObjectMeta {
             name: Some(name.to_string()),
             namespace: Some(namespace.to_string()),
             ..Default::default()
         },
-        data: Some(data),
+        data: Some(empty_data),
         ..Default::default()
     };
-
-    let config_maps: Api<ConfigMap> = Api::namespaced(client, namespace);
     let create = config_maps
         .create(&PostParams::default(), &config_map)
         .await;

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -4,28 +4,17 @@ use crds::{KbsConfig, KbsConfigSpec, Trustee};
 use json_patch::{AddOperation, PatchOperation, TestOperation};
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::api::{Patch, PatchParams, PostParams};
-use kube::{Api, Client, Error};
+use kube::{Api, Client};
 use log::info;
 use openssl::pkey::PKey;
 use std::collections::BTreeMap;
 use std::fs;
 
 use crate::reference_values::ReferenceValue;
+use crate::macros::info_if_exists;
 
 const HTTPS_KEY: &str = "kbs-https-key";
 const HTTPS_CERT: &str = "kbs-https-certificate";
-
-macro_rules! info_if_exists {
-    ($result:ident, $resource_type:literal, $resource_name:expr) => {
-        match $result {
-            Ok(_) => info!("Create {} {}", $resource_type, $resource_name),
-            Err(Error::Api(ae)) if ae.code == 409 => {
-                info!("{} {} already exists", $resource_type, $resource_name)
-            }
-            Err(e) => return Err(e.into()),
-        }
-    };
-}
 
 pub async fn generate_kbs_auth_public_key(
     client: Client,

--- a/scripts/clean-cluster-kind.sh
+++ b/scripts/clean-cluster-kind.sh
@@ -4,10 +4,11 @@ set -x
 
 source scripts/common.sh
 
-IMAGE=$1
-if ${RUNTIME} exec -ti kind-control-plane crictl inspecti ${IMAGE} &> /dev/null ; then
-	${RUNTIME} exec -ti kind-control-plane crictl rmi ${IMAGE}
-fi
-
+for image in "$@"; do
+	if ${RUNTIME} exec -ti kind-control-plane crictl inspecti ${image} &> /dev/null ; then
+		echo "Delete image ${image}"
+		${RUNTIME} exec -ti kind-control-plane crictl rmi ${image}
+	fi
+done
 kubectl delete deploy cocl-operator -n confidential-clusters || true
 

--- a/scripts/clean-cluster-kind.sh
+++ b/scripts/clean-cluster-kind.sh
@@ -11,4 +11,5 @@ for image in "$@"; do
 	fi
 done
 kubectl delete deploy cocl-operator -n confidential-clusters || true
+kubectl delete job compute-pcrs -n confidential-clusters || true
 


### PR DESCRIPTION
- Create new config map to cache known PCR values and parts.
- Fill with PCR label if present in boot image.
- Create new binary as fallback to compute values using an image volume.
- Recompute reference values based on config map.

Supersedes the reference value input workflow and #12.

Uses a config map for value caching instead of a CRD because identifying a CRD with an image ref is a little weird (character type & length limits). I'm not a huge fan either though because this means rewriting the entire map on every new image (_as we do with the reference values…_), so I'm open to other suggestions.