### PR TITLE
ci: Add initial Rust CI workflow

### DIFF
--- a/.github/workflows/cocl_basic_ci.yaml
+++ b/.github/workflows/cocl_basic_ci.yaml
@@ -1,0 +1,80 @@
+name: Basic CI test for Rust
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'operator/**'
+      - 'crds/**'
+      - 'manifest-gen/**'
+      - '.github/workflows/cocl_basic_ci.yaml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Pinned toolchain for linting
+  ACTIONS_LINTS_TOOLCHAIN: 1.89.0
+
+jobs:
+  lint:
+    name: Lint with pinned toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
+          components: rustfmt, clippy
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Run lint checks
+        run: make lint
+
+  build_and_test:
+    name: ${{ matrix.rust }} / ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - beta
+        profile:
+          - dev
+          - release
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test
+        continue-on-error: ${{ matrix.rust == 'beta' }}
+        run: |
+          if [ "${{ matrix.profile }}" == "release" ]; then
+            make test-release
+          else
+            make test
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-K8S_VERSION ?= 1.33
+
+.PHONY: all build tools manifests-dir manifests cluster-up cluster-down image push install-trustee install clean fmt-check clippy lint test test-release
+
 KUBECTL=kubectl
 
 REGISTRY ?= quay.io
@@ -7,10 +9,10 @@ IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
 all: build tools
 
 build:
-	K8S_OPENAPI_ENABLED_VERSION=$(K8S_VERSION) cargo build -p operator
+	cargo build -p operator
 
 tools:
-	K8S_OPENAPI_ENABLED_VERSION=$(K8S_VERSION) cargo build -p manifest-gen
+	cargo build -p manifest-gen
 
 manifests-dir:
 	mkdir -p manifests
@@ -45,3 +47,17 @@ install:
 clean:
 	cargo clean
 	rm -rf manifests
+
+fmt-check:
+	cargo fmt -- --check
+
+clippy:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+lint: fmt-check clippy
+
+test:
+	cargo test --workspace --all-targets
+
+test-release:
+	cargo test --workspace --all-targets --release

--- a/crds/Cargo.toml
+++ b/crds/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 kube = { version = "1.1.0", features = ["derive"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/manifest-gen/Cargo.toml
+++ b/manifest-gen/Cargo.toml
@@ -9,6 +9,6 @@ anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }
 kube = { version = "1.1.0", features = ["derive"] }
 serde_yaml = "0.9"
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 log = "0.4.27"
 env_logger = "0.11.8"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -14,7 +14,7 @@ lo = "0.0.1"
 log = "0.4.27"
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 openssl = "0.10.73"
 base64 = "0.22.1"
 anyhow = "1.0.98"

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -22,6 +22,7 @@ enum Error {}
 
 #[derive(Clone)]
 struct ContextData {
+    #[allow(dead_code)]
     client: Client,
 }
 

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -143,9 +143,7 @@ pub async fn generate_reference_values(
         .iter()
         .map(|(name, value)| {
             if let serde_json::Value::String(hex) = value
-                && hex
-                    .chars()
-                    .all(|c| (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))
+                && hex.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
             {
                 Ok(ReferenceValue {
                     version: "0.1.0".to_string(),


### PR DESCRIPTION
Sets up a workflow to run on every push and pull request for Rust source directories (`operator`, `crds`, `manifest-gen`). The workflow performs:
- Code formatting validation with `cargo fmt`
- Linting with `cargo clippy`
- Unit tests execution with `cargo test`