### PR TITLE
Enable v1_30 feature for k8s-openapi in Cargo.toml

### DIFF
--- a/crds/Cargo.toml
+++ b/crds/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 kube = { version = "1.1.0", features = ["derive"] }
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/manifest-gen/Cargo.toml
+++ b/manifest-gen/Cargo.toml
@@ -9,6 +9,6 @@ anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }
 kube = { version = "1.1.0", features = ["derive"] }
 serde_yaml = "0.9"
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 log = "0.4.27"
 env_logger = "0.11.8"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -14,7 +14,7 @@ lo = "0.0.1"
 log = "0.4.27"
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = "0.25.0"
+k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 openssl = "0.10.73"
 base64 = "0.22.1"
 anyhow = "1.0.98"


### PR DESCRIPTION
When running rust link check, it will report error like "None of the v1_* features are enabled on the k8s-openapi crate.". Update k8s-openapi dependency to enable v1_30 feature to fix the issue.