### PR TITLE
unit test: verify the func generate_kbs_auth_public_key

### DIFF
--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -23,3 +23,10 @@ serde_json = "1.0.141"
 chrono = "0.4.41"
 json-patch = "4.0.0"
 jsonptr = "0.7.1"
+
+[dev-dependencies]
+serde_json = "1.0"
+hyper = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }
+tower-test = "0.4.0"
+http-body-util = "0.1"


### PR DESCRIPTION
Testing key generation and file writing logic (e.g., whether the privateKey and publicKey file contents and base64 encoding are correct) does not require
a mock K8s client.

Signed-off-by: Dehan Meng <demeng@redhat.com>