### PR TITLE
compute-pcrs/Containerfile: Update container image reference

### DIFF
--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/confidential-clusters/compute-pcrs/buildroot AS builder
+FROM ghcr.io/confidential-clusters/buildroot AS builder
 WORKDIR /compute-pcrs
 COPY Cargo.toml Cargo.lock .
 COPY compute-pcrs compute-pcrs


### PR DESCRIPTION
We moved the buildroot image into its own repo:
https://github.com/confidential-clusters/buildroot