### PR TITLE
Build operator on container with debug support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,8 +3,28 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+ARG build_type
+# Dependency build stage
+FROM ghcr.io/confidential-clusters/buildroot AS builder
+ARG build_type
+WORKDIR /cocl-operator
+
+COPY Cargo.toml Cargo.lock .
+COPY crds crds
+COPY rv-store rv-store
+COPY operator/Cargo.toml operator/
+COPY operator/src/lib.rs operator/src/
+
+# Set only required crates as members to minimize rebuilds upon changes.
+# In debug builds, build dependencies to avoid full rebuild.
+RUN sed -i 's/members = .*/members = ["crds", "operator", "rv-store"]/' Cargo.toml && \
+    if [ "$build_type" = debug ]; then cargo build -p operator --lib; fi
+
+# Target build stage
+COPY operator/src operator/src
+RUN cargo build -p operator $(if [ "$build_type" = release ]; then echo --release; fi)
+
+# Distribution stage
 FROM quay.io/fedora/fedora:42
-
-COPY target/debug/operator /usr/bin/operator
-
-ENTRYPOINT ["/usr/bin/operator"]
+ARG build_type
+COPY --from=builder "/cocl-operator/target/$build_type/operator" /usr/bin

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ REGISTRY ?= quay.io
 OPERATOR_IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
 COMPUTE_PCRS_IMAGE=$(REGISTRY)/confidential-clusters/compute-pcrs:latest
 
+BUILD_TYPE ?= release
+
 all: build tools
 
 build:
+	cargo build -p compute-pcrs
 	cargo build -p operator
 
 tools:
@@ -34,11 +37,9 @@ cluster-up:
 cluster-down:
 	scripts/delete-cluster-kind.sh
 
-image: build
-	podman build -t $(OPERATOR_IMAGE) -f Containerfile .
-	podman build -t $(COMPUTE_PCRS_IMAGE) \
-		-f compute-pcrs/Containerfile \
-		--env K8S_OPENAPI_ENABLED_VERSION=$(K8S_VERSION) .
+image:
+	podman build --build-arg build_type=$(BUILD_TYPE) -t $(OPERATOR_IMAGE) -f Containerfile .
+	podman build --build-arg build_type=$(BUILD_TYPE) -t $(COMPUTE_PCRS_IMAGE) -f compute-pcrs/Containerfile .
 
 # TODO: remove the tls-verify, right now we are pushing only on the local registry
 push: image

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ the operator.
 
 ```bash
 make cluster-up
-make REGISTRY=localhost:5000 image
-make REGISTRY=localhost:5000 push
+make REGISTRY=localhost:5000 image push # optional: use BUILD_TYPE=debug
 make REGISTRY=localhost:5000 manifests
 make install-trustee
 make install

--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -3,17 +3,26 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+ARG build_type
 FROM ghcr.io/confidential-clusters/buildroot AS builder
+ARG build_type
 WORKDIR /compute-pcrs
+
 COPY Cargo.toml Cargo.lock .
-COPY compute-pcrs compute-pcrs
 COPY rv-store rv-store
-# Hack: Set required crates as only members to avoid needing to copy other crates.
-# In that case, a rebuild would be triggered upon any change in those crates.
+COPY compute-pcrs/Cargo.toml compute-pcrs/
+COPY compute-pcrs/src/lib.rs compute-pcrs/src/
+
+# Set only required crates as members to minimize rebuilds upon changes.
+# In debug builds, build dependencies to avoid full rebuild.
 RUN sed -i 's/members =.*/members = ["compute-pcrs", "rv-store"]/' Cargo.toml && \
     git clone --depth 1 https://github.com/confidential-clusters/reference-values && \
-    cargo build --release -p compute-pcrs
+    if [ "$build_type" = debug ]; then cargo build -p compute-pcrs --lib; fi
+
+COPY compute-pcrs/src compute-pcrs/src
+RUN cargo build -p compute-pcrs $(if [ "$build_type" = release ]; then echo --release; fi)
 
 FROM quay.io/fedora/fedora:42
-COPY --from=builder /compute-pcrs/target/release/compute-pcrs /usr/local/bin
+ARG build_type
+COPY --from=builder "/compute-pcrs/target/$build_type/compute-pcrs" /usr/bin
 COPY --from=builder /compute-pcrs/reference-values /reference-values

--- a/compute-pcrs/src/lib.rs
+++ b/compute-pcrs/src/lib.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Jakob Naucke <jnaucke@redhat.com>
+//
+// SPDX-License-Identifier: MIT
+
+// This pseudo-library exists to build dependencies in a lower
+// container layer, which speeds up development.

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: Jakob Naucke <jnaucke@redhat.com>
+//
+// SPDX-License-Identifier: MIT


### PR DESCRIPTION
Like compute-pcrs, build cocl-operator in a container. Building on the host and then copying to an F42 container is not ABI-stable.

Add support for a `BUILD_TYPE=debug` flag that uses debug builds and builds the actual binary as a separate layer for rapid development.