### PR TITLE
unit test(operator): Add comprehensive unit tests for trustee module

### DIFF
--- a/crds/src/lib.rs
+++ b/crds/src/lib.rs
@@ -16,7 +16,7 @@ pub struct ConfidentialClusterSpec {
     pub pcrs_compute_image: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Trustee {
     pub namespace: String,
     pub kbs_configuration: String,
@@ -29,7 +29,7 @@ pub struct Trustee {
     pub kbs_config_name: String,
 }
 
-#[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(CustomResource, Default, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[kube(
     group = "confidentialcontainers.org",
     version = "v1alpha1",

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -26,3 +26,9 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror = "2.0.16"
 tokio.workspace = true
+
+[dev-dependencies]
+http = "1.1.0"
+tower = { version = "0.4.13", features = ["full"] }
+# Ensure tokio test features are enabled for async tests
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
This commit introduces a full suite of 15 unit tests for the functions within `trustee.rs`, validating pure logic, error handling, and both simple and complex Kubernetes API interactions using a mocked client.

-   `test_get_image_pcrs_success`: Verifies that a valid JSON string in a ConfigMap is correctly deserialized into the `ImagePcrs` struct.
-   `test_get_image_pcrs_no_data`: Ensures an error is returned when the ConfigMap's `data` field is missing.
-   `test_get_image_pcrs_invalid_json`: Confirms that an error is propagated when the data contains an invalid JSON string.
-   `test_generate_luks_key_returns_correct_size`: A sanity check to validate that `generate_luks_key` runs without errors and returns a key of the expected 32-byte length.

These tests validate the idempotency and error handling of functions that perform a single `create` operation, primarily testing the `info_if_exists!` macro.

-   `test_create_rv_config_map_success`: Verifies the function returns `Ok(())` on a successful API response (200 OK).
-   `test_create_rv_config_map_already_exists`: Verifies the function correctly handles a 409 Conflict and returns `Ok(())`, confirming idempotency.
-   `test_create_rv_config_map_generic_error`: Ensures a generic API error (e.g., 500) is properly propagated as an `Err`.
-   `test_generate_resource_policy_success`: Validates the success path for the `generate_resource_policy` function.
-   `test_generate_kbs_https_certificate_success`: Validates the success path for the `generate_kbs_https_certificate` function.
-   `test_generate_kbs_configurations_success`: Validates the success path for the `generate_kbs_configurations` function.
-   `test_generate_attestation_policy_success`: Validates the success path for the `generate_attestation_policy` function.
-   `test_generate_kbs_success`: Validates the success path for the `generate_kbs` function.

These tests use a stateful mock client to simulate entire operational flows involving multiple API calls.

-   `test_recompute_reference_values_flow`: Verifies the complete `GET (PCRs) -> GET (RV map) -> PUT (RV map)` sequence executes successfully.
-   `test_generate_secret_flow_success`: Validates the full `CREATE (Secret) -> GET (KbsConfig) -> PATCH (KbsConfig)` workflow for adding a new secret.
-   `test_generate_secret_already_present_in_spec`: Tests the boundary condition where a secret ID already exists in the KbsConfig spec, ensuring the function exits early without making a redundant PATCH call.