### PR TITLE
Handle creation of ConfidentialClusters

### DIFF
--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -10,7 +10,9 @@
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::{Client, runtime::controller::Action};
-use std::{fmt::Display, sync::Arc, time::Duration};
+use log::info;
+use std::fmt::{Debug, Display};
+use std::{sync::Arc, time::Duration};
 
 #[derive(Clone)]
 pub struct RvContextData {
@@ -28,6 +30,13 @@ pub enum ControllerError {
 pub fn controller_error_policy<R, E: Display, C>(_obj: Arc<R>, error: &E, _ctx: Arc<C>) -> Action {
     log::error!("{error}");
     Action::requeue(Duration::from_secs(60))
+}
+
+pub async fn controller_info<T: Debug, E: Debug>(res: Result<T, E>) {
+    match res {
+        Ok(o) => info!("reconciled {o:?}"),
+        Err(e) => info!("reconcile failed: {e:?}"),
+    }
 }
 
 #[macro_export]

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use chrono::Utc;
 use compute_pcrs_lib::Pcr;
 use futures_util::StreamExt;
@@ -42,7 +42,7 @@ struct ComputePcrsOutput {
     pcrs: Vec<Pcr>,
 }
 
-pub async fn create_pcrs_config_map(client: Client) -> anyhow::Result<()> {
+pub async fn create_pcrs_config_map(client: Client) -> Result<()> {
     let empty_data = BTreeMap::from([(
         PCR_CONFIG_FILE.to_string(),
         serde_json::to_string(&ImagePcrs::default())?,
@@ -64,7 +64,7 @@ pub async fn create_pcrs_config_map(client: Client) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn fetch_pcr_label(image_ref: &str) -> anyhow::Result<Option<Vec<Pcr>>> {
+async fn fetch_pcr_label(image_ref: &str) -> Result<Option<Vec<Pcr>>> {
     let reference: oci_client::Reference = image_ref.parse()?;
     let client = oci_client::Client::new(Default::default());
     let (_, _, raw_config) = client
@@ -230,7 +230,7 @@ async fn compute_fresh_pcrs(
     Ok(())
 }
 
-pub async fn handle_new_image(ctx: RvContextData, boot_image: &str) -> anyhow::Result<()> {
+pub async fn handle_new_image(ctx: RvContextData, boot_image: &str) -> Result<()> {
     let config_maps: Api<ConfigMap> = Api::default_namespaced(ctx.client.clone());
     let mut image_pcrs_map = config_maps.get(PCR_CONFIG_MAP).await?;
     let mut image_pcrs = get_image_pcrs(image_pcrs_map.clone())?;
@@ -263,7 +263,7 @@ pub async fn handle_new_image(ctx: RvContextData, boot_image: &str) -> anyhow::R
 }
 
 #[allow(dead_code)]
-pub async fn disallow_image(ctx: RvContextData, boot_image: &str) -> anyhow::Result<()> {
+pub async fn disallow_image(ctx: RvContextData, boot_image: &str) -> Result<()> {
     let config_maps: Api<ConfigMap> = Api::default_namespaced(ctx.client.clone());
     let mut image_pcrs_map = config_maps.get(PCR_CONFIG_MAP).await?;
     let mut image_pcrs = get_image_pcrs(image_pcrs_map.clone())?;

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -28,7 +28,9 @@ use serde::Deserialize;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 
 use crate::trustee::{self, get_image_pcrs};
-use operator::{ControllerError, RvContextData, controller_error_policy, info_if_exists};
+use operator::{
+    ControllerError, RvContextData, controller_error_policy, controller_info, info_if_exists,
+};
 use rv_store::*;
 
 const JOB_LABEL_KEY: &str = "kind";
@@ -178,12 +180,7 @@ pub async fn launch_rv_job_controller(ctx: RvContextData) {
     tokio::spawn(
         Controller::new(jobs, watcher)
             .run(job_reconcile, controller_error_policy, Arc::new(ctx))
-            .for_each(|res| async move {
-                match res {
-                    Ok(o) => info!("reconciled {o:?}"),
-                    Err(e) => info!("reconcile failed: {e:?}"),
-                }
-            }),
+            .for_each(controller_info),
     );
 }
 


### PR DESCRIPTION
Previous setup had a watcher on cocl objects, but did nothing with it
and just assumed one would be present. Instead, run installations when
=1 cocl is present.

Contains two commits from #36 to make the rebase bearable (sorry)