### PR TITLE
dependabot: Ignore Warp >=0.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
       rust:
         patterns:
           - "*"
+ignore:
+  - dependency-name: "warp"
+    # Block newer versions of Warp so we can continue logging the client address,
+    # cf. https://github.com/seanmonstar/warp/issues/1127
+    versions: [">=0.4"]


### PR DESCRIPTION
API changed so logging the client address is currently very involved, cf. https://github.com/seanmonstar/warp/issues/1127. Block from updates until resolution.

Alternatively, we could decide logging the client address isn't so important.