### PR TITLE
Fix Warp ignore indentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,8 @@ updates:
       rust:
         patterns:
           - "*"
-ignore:
-  - dependency-name: "warp"
-    # Block newer versions of Warp so we can continue logging the client address,
-    # cf. https://github.com/seanmonstar/warp/issues/1127
-    versions: [">=0.4"]
+    ignore:
+      - dependency-name: "warp"
+        # Block newer versions of Warp so we can continue logging the client address,
+        # cf. https://github.com/seanmonstar/warp/issues/1127
+        versions: [">=0.4"]


### PR DESCRIPTION
#48 was incorrect.
- Sorry for the noise.
- In my defense, the CI only complains in the merge commit (meh?)
- The bad news is that this is as untested as the last one. I can't find an example that shows how to ignore Cargo crates in context; this is now based on an ignore in mongodb-kubernetes-operator (Golang).