### PR TITLE
Fix registry assignement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ NAMESPACE ?= confidential-clusters
 
 KUBECTL=kubectl
 
-REGISTRY ?= quay.io
-OPERATOR_IMAGE=$(REGISTRY)/confidential-clusters/cocl-operator:latest
-COMPUTE_PCRS_IMAGE=$(REGISTRY)/confidential-clusters/compute-pcrs:latest
-REG_SERVER_IMAGE=$(REGISTRY)/confidential-clusters/registration-server:latest
+REGISTRY ?= quay.io/confidential-clusters
+OPERATOR_IMAGE=$(REGISTRY)/cocl-operator:latest
+COMPUTE_PCRS_IMAGE=$(REGISTRY)/compute-pcrs:latest
+REG_SERVER_IMAGE=$(REGISTRY)/registration-server:latest
 # TODO add support for TPM AK verification, then move to a KBS with implemented verifier
 TRUSTEE_IMAGE ?= quay.io/confidential-clusters/key-broker-service:tpm-verifier-built-in-as-20250711
 


### PR DESCRIPTION
Make confidential-clusters as part of the registry name, hence it is possible to overwrite it