### PR TITLE
Use fedora coreos image with the clevis pin

### DIFF
--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -27,7 +27,7 @@ mod reference_values;
 mod register_server;
 mod trustee;
 
-const BOOT_IMAGE: &str = "quay.io/fedora/fedora-coreos:42.20250705.3.0";
+const BOOT_IMAGE: &str = "quay.io/confidential-clusters/fedora-coreos:latest";
 
 async fn reconcile(
     cocl: Arc<ConfidentialCluster>,


### PR DESCRIPTION
Let's reference an image built by use, so we don't encounter the risk that the image is deleted and the compute pcrs jobs continue to fail