### PR TITLE
build: Generate Rust CRDs inside build container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,10 +7,13 @@ ARG build_type
 # Dependency build stage
 FROM ghcr.io/confidential-clusters/buildroot AS builder
 ARG build_type
-WORKDIR /cocl-operator
+WORKDIR /build
 
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock go.mod go.sum Makefile .
+COPY api api
 COPY lib lib
+RUN make crds-rs
+
 COPY operator/Cargo.toml operator/
 COPY operator/src/lib.rs operator/src/
 
@@ -26,4 +29,4 @@ RUN cargo build -p operator $(if [ "$build_type" = release ]; then echo --releas
 # Distribution stage
 FROM quay.io/fedora/fedora:42
 ARG build_type
-COPY --from=builder "/cocl-operator/target/$build_type/operator" /usr/bin
+COPY --from=builder "/build/target/$build_type/operator" /usr/bin

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ cluster-up:
 cluster-down:
 	scripts/delete-cluster-kind.sh
 
-image: crds-rs
+image:
 	podman build --build-arg build_type=$(BUILD_TYPE) -t $(OPERATOR_IMAGE) -f Containerfile .
 	podman build --build-arg build_type=$(BUILD_TYPE) -t $(COMPUTE_PCRS_IMAGE) -f compute-pcrs/Containerfile .
 	podman build --build-arg build_type=$(BUILD_TYPE) -t $(REG_SERVER_IMAGE) -f register-server/Containerfile .

--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -6,10 +6,13 @@
 ARG build_type
 FROM ghcr.io/confidential-clusters/buildroot AS builder
 ARG build_type
-WORKDIR /compute-pcrs
+WORKDIR /build
 
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock go.mod go.sum Makefile .
+COPY api api
 COPY lib lib
+RUN make crds-rs
+
 COPY compute-pcrs/Cargo.toml compute-pcrs/
 COPY compute-pcrs/src/lib.rs compute-pcrs/src/
 
@@ -24,5 +27,5 @@ RUN cargo build -p compute-pcrs $(if [ "$build_type" = release ]; then echo --re
 
 FROM quay.io/fedora/fedora:42
 ARG build_type
-COPY --from=builder "/compute-pcrs/target/$build_type/compute-pcrs" /usr/bin
-COPY --from=builder /compute-pcrs/reference-values /reference-values
+COPY --from=builder "/build/target/$build_type/compute-pcrs" /usr/bin
+COPY --from=builder /build/reference-values /reference-values

--- a/register-server/Containerfile
+++ b/register-server/Containerfile
@@ -5,10 +5,13 @@
 ARG build_type
 FROM ghcr.io/confidential-clusters/buildroot AS builder
 ARG build_type
-WORKDIR /register-server
+WORKDIR /build
 
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock go.mod go.sum Makefile .
+COPY api api
 COPY lib lib
+RUN make crds-rs
+
 COPY register-server/Cargo.toml register-server/
 COPY register-server/src/lib.rs register-server/src/
 
@@ -22,6 +25,6 @@ RUN cargo build -p register-server $(if [ "$build_type" = release ]; then echo -
 
 FROM quay.io/fedora/fedora:42
 ARG build_type
-COPY --from=builder "/register-server/target/$build_type/register-server" /usr/bin
+COPY --from=builder "/build/target/$build_type/register-server" /usr/bin
 EXPOSE 3030
 ENTRYPOINT ["/usr/bin/register-server"]


### PR DESCRIPTION
Were previously built on the host, but this makes unnecessary assumptions on the build process and host. Build using Makefile.

Unify build directories across Containerfiles for better cache hits.

---
Draft but already requesting review @alicefr because we should decide before buildroot is updated. Buildroot will need to be updated anyhow, this approach additionally installs **golang** and **rustfmt**.

In this draft, the CRDs are built inside the container using the Makefile.
This approach is simpler and requires less double-tracking between Makefile and Containerfile if the setup changes. It's a little less clean because it hides what's happening from the Containerfile reader.

The best alternative I can think of runs everything from the Containerfile:
- Also install yq in the buildroot.
- Create a file (TOML or whatever) to track tool versions that we use, of controller-gen and kopium. A bonus is that kopium could be set as dev dependency in Cargo.toml and then be picked up by dependabot (ignoring that we'll lock it anyhow). I'm not aware of such a simple approach for updating a Go-based tool dependency though.
- Have Containerfile & Makefile read from this versions file to determine and install tools.

PS: If you find installing rustfmt to the build container too ugly, we can also move the formatting of kopium-generated files elsewhere. Doing so makes the lint CI slightly weirder, but is totally possible.
