### PR TITLE
build: Abstract container runtime for CI flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ within the cluster.
 ### Prerequisites
 
 -   Rust toolchain
--   `podman` or `docker`
+-   `podman` or `docker` (set `RUNTIME` environment variable accordingly)
 -   `kubectl`
 -   `kind`
 
@@ -40,7 +40,19 @@ $ ip route
 192.168.122.0/24 dev virbr0 proto kernel scope link src 192.168.122.1
 ...
 $ ip=192.168.122.1
-``
+```
+
+To use Docker:
+```bash
+export RUNTIME=docker
+```
+
+To use Podman (this export can be omitted as Podman is the default):
+```bash
+export RUNTIME=podman
+```
+
+Then run the following commands:
 
 ```bash
 make cluster-up

--- a/scripts/delete-cluster-kind.sh
+++ b/scripts/delete-cluster-kind.sh
@@ -6,5 +6,8 @@
 # SPDX-License-Identifier: CC0-1.0
 
 source scripts/common.sh
+
+$RUNTIME stop kind-registry >/dev/null 2>&1 || true
+$RUNTIME rm -f kind-registry >/dev/null 2>&1 || true
+
 kind delete cluster
-podman rm -f kind-registry


### PR DESCRIPTION
The build and cluster management scripts were previously hardcoded to use 'podman'. This limited CI/CD pipeline flexibility and assumed a specific local development environment.

This patch abstracts the container runtime by:
- Introducing a  variable in the Makefile, defaulting to 'podman', for building and pushing images.
- Updating the kind cluster scripts to use the generic variable.

These changes allow developers and CI systems to seamlessly switch between 'podman' and 'docker' by setting the
environment variable.