### PR TITLE
build: Abstract container runtime for CI flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ within the cluster.
 ### Prerequisites
 
 -   Rust toolchain
--   `podman` or `docker`
+-   `podman` or `docker` (set `CONTAINER_CLI` and `RUNTIME` environment variables accordingly)
 -   `kubectl`
 -   `kind`
 
@@ -42,6 +42,19 @@ $ ip route
 $ ip=192.168.122.1
 ```
 
+To use Docker:
+```bash
+export CONTAINER_CLI=docker
+export RUNTIME=docker
+```
+
+To use Podman (these exports can be omitted as Podman is the default):
+```bash
+export CONTAINER_CLI=podman
+export RUNTIME=podman
+```
+
+Then run the following commands:
 ```bash
 make cluster-up
 make REGISTRY=localhost:5000 PUSH_FLAGS="--tls-verify=false" push # optional: use BUILD_TYPE=debug
@@ -56,6 +69,19 @@ The KBS port will be forwarded to `8080` on your machine; the node register serv
 Run a VM as described in the
 [investigations](https://github.com/trusted-execution-clusters/investigations?tab=readme-ov-file#example-with-the-trusted-execution-clusters-operator-and-a-local-vm)
 repository.
+
+### Cleanup
+
+To clean up your environment after running tests, execute the following commands:
+```bash
+make cluster-cleanup
+# Note: You must use the same RUNTIME environment variable for `cluster-down`
+# that you used for `cluster-up`. For example:
+#
+# RUNTIME=docker make cluster-down
+RUNTIME=$RUNTIME make cluster-down
+make clean
+```
 
 ## Licenses
 

--- a/scripts/delete-cluster-kind.sh
+++ b/scripts/delete-cluster-kind.sh
@@ -6,5 +6,8 @@
 # SPDX-License-Identifier: CC0-1.0
 
 source scripts/common.sh
+
+$RUNTIME stop kind-registry >/dev/null 2>&1 || true
+$RUNTIME rm -f kind-registry >/dev/null 2>&1 || true
+
 kind delete cluster
-${RUNTIME} rm -f kind-registry


### PR DESCRIPTION
The build and cluster management scripts were previously hardcoded to use 'podman'. This limited CI/CD pipeline flexibility and assumed a specific local development environment.

This patch abstracts the container runtime by:
- Introducing a  variable in the Makefile, defaulting to 'podman', for building and pushing images.
- Updating the kind cluster scripts to use the generic variable.

These changes allow developers and CI systems to seamlessly switch between 'podman' and 'docker' by setting the
environment variable.