### PR TITLE
feat(operator): Add initial OLM bundle for the operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ trusted-cluster-gen
 /config/rbac/role.yaml
 /lib/src/kopium
 /target
+bundle/manifests/
+bundle/metadata/

--- a/Containerfile
+++ b/Containerfile
@@ -33,3 +33,4 @@ RUN cargo build -p operator $(if [ "$build_type" = release ]; then echo --releas
 FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/operator" /usr/bin
+USER nobody

--- a/bundle/Containerfile
+++ b/bundle/Containerfile
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Yalan Zhang <yalzhang@redhat.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1="registry+v1"
+LABEL operators.operatorframework.io.bundle.manifests.v1="manifests/"
+LABEL operators.operatorframework.io.bundle.metadata.v1="metadata/"
+LABEL operators.operatorframework.io.bundle.package.v1="trusted-cluster-operator"
+LABEL operators.operatorframework.io.bundle.channels.v1="alpha"
+LABEL operators.operatorframework.io.bundle.channel.default.v1="alpha"
+
+COPY manifests/ /manifests/
+COPY metadata/ /metadata/

--- a/bundle/static/manifests/trusted-cluster-operator.clusterserviceversion.yaml
+++ b/bundle/static/manifests/trusted-cluster-operator.clusterserviceversion.yaml
@@ -1,0 +1,144 @@
+---
+# SPDX-FileCopyrightText: Yalan Zhang <yalzhang@redhat.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "trusted-execution-clusters.io/v1alpha1",
+          "kind": "TrustedExecutionCluster",
+          "metadata": {
+            "name": "example-trustedexecutioncluster"
+          },
+          "spec": {
+            "trusteeImage": "quay.io/trusted-execution-clusters/key-broker-service:tpm-verifier-built-in-as-20250711",
+            "pcrsComputeImage": "quay.io/trusted-execution-clusters/compute-pcrs:latest",
+            "registerServerImage": "quay.io/trusted-execution-clusters/registration-server:latest"
+          }
+        },
+        {
+          "apiVersion": "trusted-execution-clusters.io/v1alpha1",
+          "kind": "Machine",
+          "metadata": {
+            "name": "example-machine"
+          },
+          "spec": {
+            "id": "c3e3e3e3-c3e3-c3e3-c3e3-c3e3e3e3e3e3",
+            "address": "192.168.1.100"
+          }
+        },
+        {
+          "apiVersion": "trusted-execution-clusters.io/v1alpha1",
+          "kind": "ApprovedImage",
+          "metadata": {
+            "name": "example-approvedimage"
+          },
+          "spec": {
+            "image": "quay.io/fedora/fedora-coreos@sha256:e71dad00aa0e3d70540e726a0c66407e3004d96e045ab6c253186e327a2419e5"
+          }
+        }
+      ]
+    olm.skipRange: ">=0.0.0 <1.0.0"
+    containerImage: "quay.io/trusted-execution-clusters/trusted-cluster-operator:v0.1.0"
+    capabilities: Basic Install
+  name: trusted-cluster-operator.v0.1.0
+  namespace: placeholder
+spec:
+  displayName: Trusted Execution Cluster Operator
+  description: An operator to manage trusted execution cluster, which are Kubernetes cluster that can attest their integrity to a relying party
+  version: 0.1.0
+  minKubeVersion: "1.27.0"
+  provider:
+    name: Red Hat
+  icon:
+    - base64data: "<base64 PNG>"
+      mediatype: "image/png"
+  # replaces: trusted-cluster-operator.vX.Y.Z # Uncomment and set this to the previous CSV name when updating the operator.
+
+  maturity: alpha
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: false
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: trusted-cluster-operator
+          # Rules are dynamically generated from config/rbac/role.yaml during the bundle build
+          rules: []
+      deployments:
+        - name: trusted-cluster-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: trusted-cluster-operator
+            template:
+              metadata:
+                labels:
+                  name: trusted-cluster-operator
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 65534
+                serviceAccountName: trusted-cluster-operator
+                containers:
+                  - name: trusted-cluster-operator
+                    image: quay.io/trusted-execution-clusters/trusted-cluster-operator:v0.1.0
+                    command:
+                      - /usr/bin/operator
+                    imagePullPolicy: IfNotPresent
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: "trusted-cluster-operator"
+                      - name: COMPUTE_PCRS_IMAGE
+                        value: "quay.io/trusted-execution-clusters/compute-pcrs:v0.1.0"
+                      - name: REGISTER_SERVER_IMAGE
+                        value: "quay.io/trusted-execution-clusters/registration-server:v0.1.0"
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+  customresourcedefinitions:
+    owned:
+      - name: trustedexecutionclusters.trusted-execution-clusters.io
+        version: v1alpha1
+        kind: TrustedExecutionCluster
+        displayName: Trusted Execution Cluster
+        description: Represents a trusted execution cluster.
+      - name: machines.trusted-execution-clusters.io
+        version: v1alpha1
+        kind: Machine
+        displayName: Machine
+        description: Represents a machine in a trusted execution cluster.
+      - name: approvedimages.trusted-execution-clusters.io
+        version: v1alpha1
+        kind: ApprovedImage
+        displayName: Approved Image
+        description: Represents a container image approved for execution.

--- a/bundle/static/metadata/annotations.yaml
+++ b/bundle/static/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Yalan Zhang <yalzhang@redhat.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: trusted-cluster-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -32,3 +32,4 @@ FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/compute-pcrs" /usr/bin
 COPY --from=builder /build/reference-values /reference-values
+USER nobody

--- a/register-server/Containerfile
+++ b/register-server/Containerfile
@@ -29,5 +29,6 @@ RUN cargo build -p register-server $(if [ "$build_type" = release ]; then echo -
 FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/register-server" /usr/bin
+USER nobody
 EXPOSE 3030
 ENTRYPOINT ["/usr/bin/register-server"]

--- a/scripts/generate-bundle-prod.sh
+++ b/scripts/generate-bundle-prod.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Yalan Zhang <yalzhang@redhat.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+set -euo pipefail
+
+BUNDLE_VERSION=""
+PREVIOUS_CSV=""
+
+while getopts "v:p:" opt; do
+  case $opt in
+    v) BUNDLE_VERSION="$OPTARG" ;;
+    p) PREVIOUS_CSV="$OPTARG" ;;
+    *) echo "Usage: $0 -v <bundle-version> [-p <previous-csv>]"; exit 1 ;;
+  esac
+done
+
+[[ -z "$BUNDLE_VERSION" ]] && { echo "Error: bundle version cannot be empty"; exit 1; }
+
+# Required environment variables
+for var in OPERATOR_IMAGE COMPUTE_PCRS_IMAGE REG_SERVER_IMAGE; do
+    : "${!var:?Please export $var}"
+done
+
+PROJECT_ROOT="$(pwd)"
+BUNDLE_DIR="${PROJECT_ROOT}/bundle"
+BUNDLE_MANIFESTS="${BUNDLE_DIR}/manifests"
+BUNDLE_METADATA="${BUNDLE_DIR}/metadata"
+CSV_TEMPLATE="${PROJECT_ROOT}/bundle/static/manifests/trusted-cluster-operator.clusterserviceversion.yaml"
+ANNOTATIONS_TEMPLATE="${PROJECT_ROOT}/bundle/static/metadata/annotations.yaml"
+RBAC_ROLE_FILE="${PROJECT_ROOT}/config/rbac/role.yaml"
+
+echo "=> Cleaning previous bundle..."
+rm -rf "${BUNDLE_MANIFESTS}" "${BUNDLE_METADATA}"
+mkdir -p "${BUNDLE_MANIFESTS}" "${BUNDLE_METADATA}"
+
+echo "=> Copying CRDs and static assets..."
+shopt -s nullglob
+cp "${PROJECT_ROOT}/config/crd"/*.yaml "${BUNDLE_MANIFESTS}/"
+cp "$CSV_TEMPLATE" "${BUNDLE_MANIFESTS}/"
+cp "$ANNOTATIONS_TEMPLATE" "${BUNDLE_METADATA}/"
+
+echo "=> Patching CSV with images, env vars, version, and RBAC rules..."
+CSV_FILE="${BUNDLE_MANIFESTS}/trusted-cluster-operator.clusterserviceversion.yaml"
+
+# Patch metadata and version
+yq -i ".metadata.name = \"trusted-cluster-operator.v${BUNDLE_VERSION}\"" "$CSV_FILE"
+yq -i ".spec.version = \"${BUNDLE_VERSION}\"" "$CSV_FILE"
+yq -i ".metadata.annotations.containerImage = \"${OPERATOR_IMAGE}\"" "$CSV_FILE"
+
+# Patch deployment container image
+yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image = \"${OPERATOR_IMAGE}\"" "$CSV_FILE"
+
+# Patch environment variables
+for env_var in COMPUTE_PCRS_IMAGE REG_SERVER_IMAGE; do
+  yq -i "(.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] | select(.name == \"$env_var\")).value = \"${!env_var}\"" "$CSV_FILE"
+done
+
+# Patch RBAC rules
+yq -i ".spec.install.spec.permissions[0].rules = load(\"${RBAC_ROLE_FILE}\").rules" "$CSV_FILE"
+
+# Set .spec.replaces for automatic upgrades if provided
+if [[ -n "$PREVIOUS_CSV" ]]; then
+  echo "=> Setting .spec.replaces to $PREVIOUS_CSV"
+  yq -i ".spec.replaces = \"$PREVIOUS_CSV\"" "$CSV_FILE"
+fi
+
+echo "=> Validating OLM bundle..."
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cp -r "${BUNDLE_MANIFESTS}" "$TMP_DIR/manifests"
+cp -r "${BUNDLE_METADATA}" "$TMP_DIR/metadata"
+
+(cd "$TMP_DIR" && operator-sdk bundle validate . --select-optional suite=operatorframework --verbose)
+
+echo "=> Bundle validated successfully!"
+echo "=> OLM bundle ready at ${BUNDLE_DIR}"


### PR DESCRIPTION
Introduces OLM bundle generation for the operator, enabling OLM-based
deployment and management.

Key changes include:
- `Makefile` targets (`bundle`, `bundle-image`, `push-bundle`, `push-all`)
  for automated bundle generation, building, and pushing.
- New `bundle/` directory structure for OLM artifacts, with static templates
  and generated manifests.
- Security enhancement in `Containerfile` to run as a non-root user.
- Updated `README.md` with OLM bundle management workflows.
- `bundle/manifests/` added to `.gitignore`.