### PR TITLE
Delay secret unmount

### DIFF
--- a/api/v1alpha1/crds.go
+++ b/api/v1alpha1/crds.go
@@ -27,7 +27,7 @@ var (
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=create
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=create
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;create;update
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete;list;watch
 // +kubebuilder:rbac:groups=trusted-execution-clusters.io,resources=trustedexecutionclusters,verbs=list;watch


### PR DESCRIPTION
Previously, disk encryption secrets were deleted directly with the
associated machine resource, and subsequently unmounted from Trustee
pods, which causes a pod restart. Because secret deletion is merely
housekeeping, not a time-critical purge, delay unmount until the next
secret mount: Whenever secrets are to be mounted, partition secrets
into "mount" and "discard".

Picks one tests-related commit out of #111.