### PR TITLE
fix(bundle): resolve OLM installation and runtime errors

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,4 +33,3 @@ RUN cargo build -p operator $(if [ "$build_type" = release ]; then echo --releas
 FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/operator" /usr/bin
-USER nobody

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ release-tarball: manifests
 # OLM Bundle related variables
 BUNDLE_DIR := bundle
 BUNDLE_IMAGE := $(REGISTRY)/trusted-cluster-operator-bundle:$(TAG)
-BUNDLE_PACKAGE ?= trusted-cluster-operator
 PREVIOUS_CSV ?= ""  # optional previous CSV for OLM upgrades
 
 .PHONY: bundle bundle-image push-bundle
@@ -114,7 +113,7 @@ bundle: manifests
 	@OPERATOR_IMAGE=$(OPERATOR_IMAGE) \
 	COMPUTE_PCRS_IMAGE=$(COMPUTE_PCRS_IMAGE) \
 	REG_SERVER_IMAGE=$(REG_SERVER_IMAGE) \
-	scripts/generate-bundle-prod.sh -v $(TAG) $(if $(PREVIOUS_CSV),-p $(PREVIOUS_CSV))
+	scripts/generate-bundle-prod.sh -v $(TAG) -n $(NAMESPACE) $(if $(PREVIOUS_CSV),-p $(PREVIOUS_CSV))
 
 bundle-image: bundle
 	@echo "Building OLM bundle image..."

--- a/bundle/static/manifests/trusted-cluster-operator.clusterserviceversion.yaml
+++ b/bundle/static/manifests/trusted-cluster-operator.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
   install:
     strategy: deployment
     spec:
-      permissions:
+      clusterPermissions:
         - serviceAccountName: trusted-cluster-operator
           # Rules are dynamically generated from config/rbac/role.yaml during the bundle build
           rules: []

--- a/compute-pcrs/Containerfile
+++ b/compute-pcrs/Containerfile
@@ -32,4 +32,3 @@ FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/compute-pcrs" /usr/bin
 COPY --from=builder /build/reference-values /reference-values
-USER nobody

--- a/register-server/Containerfile
+++ b/register-server/Containerfile
@@ -29,6 +29,5 @@ RUN cargo build -p register-server $(if [ "$build_type" = release ]; then echo -
 FROM quay.io/fedora/fedora:42
 ARG build_type
 COPY --from=builder "/build/target/$build_type/register-server" /usr/bin
-USER nobody
 EXPOSE 3030
 ENTRYPOINT ["/usr/bin/register-server"]


### PR DESCRIPTION
This commit fixes issues that prevented the operator from installing and running correctly via an OLM bundle.

Key changes:
- Use `clusterPermissions` in CSV to ensure correct cluster-wide RBAC.
- Automate RBAC manifests copying and namespace patching in the bundle.
- Remove `USER nobody` from Containerfiles to avoid runtime permission errors.