### PR TITLE
Fix: Prevent integration test hangs by handling ssh-add asynchronously

### DIFF
--- a/tests/attestation.rs
+++ b/tests/attestation.rs
@@ -19,7 +19,7 @@ impl SingleAttestationContext {
         let client = test_ctx.client();
         let namespace = test_ctx.namespace();
 
-        let (_private_key, public_key, key_path) = virt::generate_ssh_key_pair()?;
+        let (_private_key, public_key, key_path) = virt::generate_ssh_key_pair().await?;
         test_ctx.info(format!(
             "Generated SSH key pair and added to ssh-agent: {:?}",
             key_path
@@ -96,8 +96,8 @@ async fn test_parallel_vm_attestation() -> anyhow::Result<()> {
     test_ctx.info("Testing parallel VM attestation - launching 2 VMs simultaneously");
 
     // Generate SSH keys for both VMs
-    let (_private_key1, public_key1, key_path1) = virt::generate_ssh_key_pair()?;
-    let (_private_key2, public_key2, key_path2) = virt::generate_ssh_key_pair()?;
+    let (_private_key1, public_key1, key_path1) = virt::generate_ssh_key_pair().await?;
+    let (_private_key2, public_key2, key_path2) = virt::generate_ssh_key_pair().await?;
     test_ctx.info("Generated SSH key pairs for both VMs");
 
     let register_server_url = format!(


### PR DESCRIPTION
The integration tests were intermittently hanging due to a synchronous call to `ssh-add` within the `virt::generate_ssh_key_pair` function. This blocking operation would starve the  asynchronous runtime, preventing further test execution, including KubeVirt VM creation.

This commit resolves the issue by:
- Converting  in `virt::generate_ssh_key_pair` in `test_utils/src/virt.rs` to an  function.
- Wrapping the synchronous `ssh-add` command within `tokio::task::spawn_blocking` to execute it on a dedicated blocking thread, thus avoiding starvation of the main asynchronous test thread.
- Updating all call sites in `tests/attestation.rs` to correctly `await` the `virt::generate_ssh_key_pair` function, aligning them with its new asynchronous nature.