### PR TITLE
Increase VM boot timeout to prevent SSH wait failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ test: crds-rs
 test-release: crds-rs
 	cargo test --workspace --bins --release
 
-integration-tests: generate trusted-cluster-gen
+integration-tests: generate trusted-cluster-gen crds-rs
 	RUST_LOG=info cargo test --test trusted_execution_cluster --test attestation \
 		--features virtualization -- --no-capture  --test-threads=1
 

--- a/test_utils/src/virt.rs
+++ b/test_utils/src/virt.rs
@@ -193,6 +193,7 @@ pub async fn create_kubevirt_vm(
                         },
                         "resources": {
                             "requests": {
+                                "cpu": "2",
                                 "memory": "4096M"
                             }
                         }

--- a/tests/trusted_execution_cluster.rs
+++ b/tests/trusted_execution_cluster.rs
@@ -62,8 +62,10 @@ async fn test_image_pcrs_configmap_updates() -> anyhow::Result<()> {
 
                 if let Some(data) = &cm.data {
                     if let Some(image_pcrs_json) = data.get("image-pcrs.json") {
-                        if !image_pcrs_json.is_empty() {
-                            return Ok(());
+                        if let Ok(image_pcrs) = serde_json::from_str::<ImagePcrs>(image_pcrs_json) {
+                            if !image_pcrs.0.is_empty() {
+                                return Ok(());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The `test_attestation` test may time out while waiting for SSH access, as VM boot can exceed the previous 300s limit. Increase the maximum wait time to 600s to prevent this.
Also, update the `integration-tests` target in the Makefile to add the `crds-rs` dependency and ensure the namespace is created before applying the manifests.