### PR TITLE
Revert to use unified attestation policies

### DIFF
--- a/operator/src/resource.rego
+++ b/operator/src/resource.rego
@@ -5,5 +5,4 @@ default allow := false
 
 allow if {
   input["submods"]["cpu0"]["ear.status"] == "affirming"
-  input["submods"]["cpu0"]["ear.veraison.annotated-evidence"]["tpm"]
 }

--- a/operator/src/tpm.rego
+++ b/operator/src/tpm.rego
@@ -1,19 +1,21 @@
 package policy
+
 import rego.v1
-default hardware := 97
-default configuration := 36
+
+default hardware := 2
+
+default configuration := 2
+
 default executables := 33
 
-##### TPM
-hardware := 2 if {
-  input.tpm.svn in data.reference.tpm_svn
+## TPM validation
+executables := 3 if {
+	lower(input.tpm.pcrs[4]) in data.reference.tpm_pcr4
+	lower(input.tpm.pcrs[14]) in data.reference.tpm_pcr14
 }
 
-tpm_pcrs_valid if {
-  lower(input.tpm.pcrs[4]) in data.reference.tpm_pcr4
-##  lower(input.tpm.pcrs[7]) in data.reference.tpm_pcr7
-  lower(input.tpm.pcrs[14]) in data.reference.tpm_pcr14
+# Azure SNP vTPM validation
+executables := 3 if {
+	lower(input.azsnpvtpm.tpm.pcr04) in data.reference.tpm_pcr4
+	lower(input.azsnpvtpm.tpm.pcr14) in data.reference.tpm_pcr14
 }
-
-executables := 3 if tpm_pcrs_valid
-configuration := 2 if tpm_pcrs_valid


### PR DESCRIPTION
Replace KubeVirt-specific OPA policies with unified policies that support both KubeVirt VMs and Azure VMs with AMD SEV-SNP.