### PR TITLE
rvs: Introduce pod pending reason

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -20,6 +20,7 @@ const (
 	NotCommittedReasonComputing string = "Computing"
 	NotCommittedReasonNoDigest  string = "NoDigestGiven"
 	NotCommittedReasonFailed    string = "ComputationFailed"
+	NotCommittedReasonPending   string = "PodPending"
 
 	// Conditions for the AttestationKey
 	AttestationKeyApprovedCondition     string = "Approved"

--- a/api/v1alpha1/crds.go
+++ b/api/v1alpha1/crds.go
@@ -26,6 +26,7 @@ var (
 )
 
 // +kubebuilder:rbac:groups="",resources=configmaps;services;secrets,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=trusted-execution-clusters.io,resources=trustedexecutionclusters;machines;approvedimages;attestationkeys,verbs=create;delete;get;list;patch;update;watch

--- a/lib/src/conditions.rs
+++ b/lib/src/conditions.rs
@@ -17,6 +17,7 @@ pub const COMMITTED_REASON: &str = "ImageCommitted";
 pub const NOT_COMMITTED_REASON_COMPUTING: &str = "Computing";
 pub const NOT_COMMITTED_REASON_NO_DIGEST: &str = "NoDigestGiven";
 pub const NOT_COMMITTED_REASON_FAILED: &str = "ComputationFailed";
+pub const NOT_COMMITTED_REASON_PENDING: &str = "PodPending";
 
 pub const ATTESTATION_KEY_APPROVED_CONDITION: &str = "Approved";
 pub const ATTESTATION_KEY_REGISTRATION_REASON: &str = "Registration";

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,6 +51,7 @@ pub fn committed_condition(reason: &str, generation: Option<i64>) -> Condition {
                 "Image did not specify a digest. \
                  Only images with a digest are supported to avoid ambiguity."
             }
+            NOT_COMMITTED_REASON_PENDING => "Pod is pending, check pods for details",
             NOT_COMMITTED_REASON_FAILED => "Computation failed, check operator log for details",
             _ => "",
         }

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -9,14 +9,13 @@ use futures_util::StreamExt;
 use k8s_openapi::{
     api::{
         batch::v1::{Job, JobSpec},
-        core::v1::{
-            ConfigMap, Container, ImageVolumeSource, PodSpec, PodTemplateSpec, Volume, VolumeMount,
-        },
+        core::v1::{ConfigMap, Container, ImageVolumeSource, Volume, VolumeMount},
+        core::v1::{Pod, PodSpec, PodTemplateSpec},
     },
     apimachinery::pkg::apis::meta::v1::OwnerReference,
     jiff::Timestamp,
 };
-use kube::api::{DeleteParams, ObjectMeta};
+use kube::api::{DeleteParams, ListParams, ObjectMeta};
 use kube::runtime::{
     controller::{Action, Controller},
     finalizer,
@@ -39,6 +38,7 @@ use operator::{
 use trusted_cluster_operator_lib::{conditions::*, reference_values::*, *};
 
 const JOB_LABEL_KEY: &str = "kind";
+const APPROVED_IMAGE_ANNOTATION: &str = "approved-image";
 const PCR_COMMAND_NAME: &str = "compute-pcrs";
 const PCR_LABEL: &str = "org.coreos.pcrs";
 /// Finalizer name to discard reference values when an image is no longer approved
@@ -179,8 +179,14 @@ async fn compute_fresh_pcrs(
         },
         spec: Some(JobSpec {
             template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(BTreeMap::from([(
+                        APPROVED_IMAGE_ANNOTATION.to_string(),
+                        resource_name.to_string(),
+                    )])),
+                    ..Default::default()
+                }),
                 spec: Some(pod_spec),
-                ..Default::default()
             },
             ..Default::default()
         }),
@@ -292,7 +298,15 @@ async fn image_add_reconcile(
     }
 
     let (action, reason) = match handle_new_image(ctx, name, &image.spec.image).await {
-        Ok(reason) => (Action::await_change(), reason),
+        Ok(reason) => {
+            let action = match reason {
+                NOT_COMMITTED_REASON_COMPUTING | NOT_COMMITTED_REASON_PENDING => {
+                    Action::requeue(Duration::from_secs(10))
+                }
+                _ => Action::await_change(),
+            };
+            (action, reason)
+        }
         Err(e) => {
             warn!("PCR computation for {name} failed: {e}");
             let action = Action::requeue(Duration::from_secs(60));
@@ -314,6 +328,17 @@ pub async fn launch_rv_image_controller(ctx: RvContextData) {
             .run(image_reconcile, controller_error_policy, Arc::new(ctx))
             .for_each(controller_info),
     );
+}
+
+async fn is_pending(client: &Client, resource_name: &str) -> Result<bool> {
+    let pods: Api<Pod> = Api::default_namespaced(client.clone());
+    let lp = ListParams::default().labels(&format!("{APPROVED_IMAGE_ANNOTATION}={resource_name}"));
+    let pod_list = pods.list(&lp).await?;
+    Ok(pod_list
+        .iter()
+        .max_by_key(|pod| pod.metadata.creation_timestamp.as_ref().map(|t| t.0))
+        .and_then(|pod| pod.status.as_ref().and_then(|s| s.phase.as_ref()))
+        .is_some_and(|phase| phase == "Pending"))
 }
 
 pub async fn handle_new_image(
@@ -344,6 +369,9 @@ pub async fn handle_new_image(
     let compute_pcrs = match label {
         Err(ref e) => {
             warn!("Fetching PCR label for {image_ref} failed: {e}. Falling back to computation.");
+            if is_pending(&ctx.client, resource_name).await? {
+                return Ok(NOT_COMMITTED_REASON_PENDING);
+            }
             true
         }
         Ok(None) => {

--- a/tests/trusted_execution_cluster.rs
+++ b/tests/trusted_execution_cluster.rs
@@ -7,6 +7,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
 use kube::{Api, api::DeleteParams};
 use std::time::Duration;
+use trusted_cluster_operator_lib::conditions::NOT_COMMITTED_REASON_PENDING;
 use trusted_cluster_operator_lib::reference_values::ImagePcrs;
 use trusted_cluster_operator_lib::{
     ApprovedImage, AttestationKey, Machine, TrustedExecutionCluster, generate_owner_reference,
@@ -431,6 +432,47 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
 
     test_ctx.cleanup().await?;
 
+    Ok(())
+}
+}
+
+named_test! {
+async fn test_nonexistent_approved_image() -> anyhow::Result<()> {
+    let test_ctx = setup!().await?;
+    let client = test_ctx.client();
+    let namespace = test_ctx.namespace();
+
+    let images: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
+    images.create(&Default::default(), &ApprovedImage {
+        metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+            name: Some("coreos1".to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: trusted_cluster_operator_lib::ApprovedImageSpec {
+            image: "quay.io/trusted-execution-clusters/fedora-coreos@sha256:0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        },
+        status: None,
+    }).await?;
+
+    let poller = Poller::new()
+        .with_timeout(Duration::from_secs(30))
+        .with_interval(Duration::from_millis(500))
+        .with_error_message("ApprovedImage not created".to_string());
+    poller.poll_async(|| {
+        let api = images.clone();
+        async move {
+            let img = api.get("coreos1").await?;
+            if img.status.as_ref().and_then(|s| s.conditions.as_ref()).map(|conditions| {
+                conditions.iter().any(|c| c.reason == NOT_COMMITTED_REASON_PENDING)
+            }).unwrap_or(false) {
+                return Ok(());
+            }
+            Err(anyhow::anyhow!("ApprovedImage not yet committed"))
+        }
+    }).await?;
+
+    test_ctx.cleanup().await?;
     Ok(())
 }
 }


### PR DESCRIPTION
to avoid misleading "computation is ongoing" reason when e.g. image pull fails. Watching for image and pod events within one reconciliation has some gotchas, so requeue if computing or pending.

Fixes: #241