### PR TITLE
dependabot: Do not update the Go toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
       golang:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "go"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
Keep 1.25, RHEL-supported version, like we do for Rust (except dependabot doesn't update that on its own at all).

I find it defensible to skip integration tests on this one. I believe that unfortunately, there is no way to test a dependabot configuration before merge (except for formal validity), so we'll just need to try this one.