### PR TITLE
Update documentation with deploy script and other minor changes

### DIFF
--- a/docs/usage/getting-started-guide.md
+++ b/docs/usage/getting-started-guide.md
@@ -13,7 +13,7 @@ Kind can be used with `docker` or `podman`. Although, we set `podman` as default
 export RUNTIME=docker
 ```
 
-Also make sure the container CLI environment variable is configured
+The `CONTAINER_CLI` env var will used for building and pushing. If you require a non-Podman engine for building and pushing images, you can override it with the `$CONTAINER_CLI` variable.
 ```console
 export CONTAINER_CLI=docker
 ```
@@ -86,21 +86,15 @@ export TRUSTEE_ADDR=kbs-service.trusted-execution-clusters.svc.cluster.local
 export AK_REGISTRATION_ADDR=attestation-key-register.trusted-execution-clusters.svc.cluster.local
 
 ```
-This example works with KubeVirt when the KBS is reachable using the pod networking.
-
-Make sure Kube-virt is also installed before trying to install the operator and testing functionality.
-```console
-make install-kubevirt
-```
 
 Finally, the operator can be installed with:
 ```console
 make install
 ```
 
-Wait for cluster to be ready:
+Wait for cluster to be ready and in installed state:
 ```console
-sleep 10m
+kubectl wait -n trusted-execution-clusters --for=condition=Installed TrustedExecutionCluster trusted-execution-cluster
 ```
 
 Print cluster status
@@ -108,11 +102,8 @@ Print cluster status
 kubectl -n trusted-execution-clusters get po,svc
 ```
 
-
-Refer to the one-shot deploy script at the end of this README for a quick install once you've understood the process.
-
 Further customization of the project can be controlled with the following env variables:
-+ NAMESPACE: sets the namespace where the operator will be deplyoed
++ NAMESPACE: sets the namespace where the operator will be deployed
 + PLATFORM: use during the installation to configure the platform where the operator will be deployed (`kind` or `openshift`)
 + INTEGRATION_TEST_THREADS: how many integration tests are run in parallel
 + REGISTRY: the registry used to publish the images
@@ -161,40 +152,3 @@ kubectl logs -n trusted-execution-clusters <trustee-deplyoment>
 ```
 
 In the logs, trustee prints the content of the TPM PCR registers. They need to match with the reference values present in the configmap `trustee-data` under `reference-values.json`.
-
-## One shot deploy script
-
-```bash
-#! /bin/bash
-set -euo pipefail
-set -v
-
-# kind exports
-export CONTAINER_CLI=docker
-export RUNTIME=docker
-
-# oparator exports
-export AK_REGISTRATION_ADDR=attestation-key-register.trusted-execution-clusters.svc.cluster.local
-export TRUSTEE_ADDR=kbs-service.trusted-execution-clusters.svc.cluster.local
-export REGISTRY=localhost:5000/trusted-cluster-operator
-
-# clean and create new cluster
-make cluster-down
-make cluster-up
-make install-kubevirt
-
-# install operator
-make push
-make manifests
-make install
-
-# print cluster status
-kubectl -n trusted-execution-clusters get po,svc
-
-# wait for cluster to be ready
-sleep 10m
-
-# create Vm
-examples/create-ignition-secret.sh examples/ignition-coreos.json coreos-ignition-secret
-kubectl apply -f examples/vm-coreos-ign.yaml
-```

--- a/docs/usage/getting-started-guide.md
+++ b/docs/usage/getting-started-guide.md
@@ -13,12 +13,23 @@ Kind can be used with `docker` or `podman`. Although, we set `podman` as default
 export RUNTIME=docker
 ```
 
+Also make sure the container CLI environment variable is configured
+```console
+export CONTAINER_CLI=docker
+```
+
 In order to interact with the cluster, `kubectl` is required.
 ```console
 dnf install -y kubectl
 ```
 
-Our kind cluster configuration is available under the `kind` directory and it uses the script `scripts/create-cluster-kind.sh`. The cluster can be simply created by running:
+Our kind cluster configuration is available under the `kind` directory and it uses the script `scripts/create-cluster-kind.sh`. 
+Make sure any previously installed cluster is deleted before attempting to install a new one:
+```console
+make cluster-down
+```
+
+The cluster can be simply created by running:
 ```console
 make cluster-up
 ```
@@ -77,10 +88,28 @@ export AK_REGISTRATION_ADDR=attestation-key-register.trusted-execution-clusters.
 ```
 This example works with KubeVirt when the KBS is reachable using the pod networking.
 
+Make sure Kube-virt is also installed before trying to install the operator and testing functionality.
+```console
+make install-kubevirt
+```
+
 Finally, the operator can be installed with:
 ```console
 make install
 ```
+
+Wait for cluster to be ready:
+```console
+sleep 10m
+```
+
+Print cluster status
+```console
+kubectl -n trusted-execution-clusters get po,svc
+```
+
+
+Refer to the one-shot deploy script at the end of this README for a quick install once you've understood the process.
 
 Further customization of the project can be controlled with the following env variables:
 + NAMESPACE: sets the namespace where the operator will be deplyoed
@@ -132,3 +161,40 @@ kubectl logs -n trusted-execution-clusters <trustee-deplyoment>
 ```
 
 In the logs, trustee prints the content of the TPM PCR registers. They need to match with the reference values present in the configmap `trustee-data` under `reference-values.json`.
+
+## One shot deploy script
+
+```bash
+#! /bin/bash
+set -euo pipefail
+set -v
+
+# kind exports
+export CONTAINER_CLI=docker
+export RUNTIME=docker
+
+# oparator exports
+export AK_REGISTRATION_ADDR=attestation-key-register.trusted-execution-clusters.svc.cluster.local
+export TRUSTEE_ADDR=kbs-service.trusted-execution-clusters.svc.cluster.local
+export REGISTRY=localhost:5000/trusted-cluster-operator
+
+# clean and create new cluster
+make cluster-down
+make cluster-up
+make install-kubevirt
+
+# install operator
+make push
+make manifests
+make install
+
+# print cluster status
+kubectl -n trusted-execution-clusters get po,svc
+
+# wait for cluster to be ready
+sleep 10m
+
+# create Vm
+examples/create-ignition-secret.sh examples/ignition-coreos.json coreos-ignition-secret
+kubectl apply -f examples/vm-coreos-ign.yaml
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,8 @@ Upon a successful test, the namespace is cleaned up, otherwise it is kept for in
 The tests use [`virtctl`](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/) in order to interact with
 VM, like getting the serial console and verifying that the guest has correctly booted by ssh-ing into it.
 
+Other dependencies: *openssl-devel, gcc-c++*
+
 N.B KubeVirt requires the cluster to be run as a privileged container on the host in order to handle the devices. Therefore, for now, we have moved to Docker with kind in order to generate the cluster. In the future, we might be able to move to rootful podman.
 
 Run the tests locally with kind:


### PR DESCRIPTION
Added deploy script + minor changes

## Summary by Sourcery

Update the getting started guide to document a full one-shot deployment flow and required environment/setup steps for creating and using a kind-based cluster with the operator.

Enhancements:
- Add a documented one-shot deploy bash script that automates cluster creation, KubeVirt and operator installation, and a sample VM deployment for quick end-to-end testing.

Documentation:
- Expand the getting started guide with required environment variables, cluster cleanup and setup steps, KubeVirt installation, cluster readiness checks, and references to a new one-shot deploy script.