### PR TITLE
Fixes on tests & kbs-cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 
 .PHONY: all build build-tools crds-rs generate manifests cluster-up cluster-down image push install-trustee install clean fmt-check clippy lint test test-release release-tarball
 
+SHELL := /bin/bash
+
 NAMESPACE ?= trusted-execution-clusters
 PLATFORM ?= kind
 

--- a/attestation-key-register/src/main.rs
+++ b/attestation-key-register/src/main.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+use axum::extract::State;
 use axum::response::{IntoResponse, Json};
 use axum::{http::StatusCode, routing::put, Router};
 use axum_server::tls_openssl::OpenSSLConfig;
@@ -43,6 +44,7 @@ struct AttestationKeyRegistration {
 }
 
 async fn handle_registration(
+    State(client): State<Client>,
     Json(registration): Json<AttestationKeyRegistration>,
 ) -> impl IntoResponse {
     info!("Received registration request: {registration:?}");
@@ -55,11 +57,6 @@ async fn handle_registration(
             "message": format!("{e:#}"),
         });
         (code, Json(msg))
-    };
-
-    let client = match Client::try_default().await {
-        Ok(c) => c,
-        Err(e) => return internal_error(e.into()),
     };
 
     let api: Api<AttestationKey> = Api::default_namespaced(client.clone());
@@ -133,15 +130,20 @@ async fn main() {
 
     let args = Args::parse();
     let endpoint = format!("/{ATTESTATION_KEY_REGISTER_RESOURCE}");
-    let app = Router::new().route(&endpoint, put(handle_registration));
+    let err = "failed to create Kubernetes client";
+    let client = Client::try_default().await.expect(err);
+    let app = Router::new()
+        .route(&endpoint, put(handle_registration))
+        .with_state(client);
     let addr = SocketAddr::from(([0, 0, 0, 0], args.port));
     let service = app.into_make_service();
-    info!("Starting attestation key registration server on http://{addr}",);
 
     let run = if let (Some(cert_path), Some(key_path)) = (args.cert_path, args.key_path) {
         let config = OpenSSLConfig::from_pem_file(cert_path, key_path).expect("invalid PEM files");
+        info!("Starting attestation key registration server on https://{addr}");
         axum_server::bind_openssl(addr, config).serve(service).await
     } else {
+        info!("Starting attestation key registration server on http://{addr}");
         axum_server::bind(addr).serve(service).await
     };
     run.expect("Server failed");

--- a/docs/usage/tls.md
+++ b/docs/usage/tls.md
@@ -105,7 +105,7 @@ spec:
 
 ### To the node
 
-Retrieve the root CA public key, percent-encode it and add it as a certifiate authority to the Ignition given to the node:
+Retrieve the root CA public key, percent-encode it and add it as a certificate authority to the Ignition given to the node:
 
 ```sh
 $ kubectl get secret root-secret -n trusted-execution-clusters -o json | jq -r '.data["ca.crt"]' | base64 -d | jq -sRr @uri

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -127,6 +127,7 @@ where
 
 // TODO: Port this functionality to kube-rs API.
 // Update condition if already present, otherwise append(insert) it into the conditions vector.
+// Inspired by k8s.io/apimachinery/pkg/api/meta.SetStatusCondition
 pub fn upsert_condition(
     existing_conditions: &mut Option<Vec<Condition>>,
     new_condition: Condition,

--- a/register-server/src/main.rs
+++ b/register-server/src/main.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+use axum::extract::State;
 use axum::response::{IntoResponse, Json};
 use axum::{http::StatusCode, routing::get, Router};
 use axum_server::tls_openssl::OpenSSLConfig;
@@ -58,7 +59,7 @@ async fn get_ca(client: Client, secret_name: &str) -> anyhow::Result<String> {
     let secret = secrets.get(secret_name).await?;
     let err = format!("Secret {secret_name} does not contain ca.crt");
     let ca_data = secret.data.as_ref();
-    let ca_bytes = ca_data.and_then(|data| data.get("ca.crt")).expect(&err);
+    let ca_bytes = ca_data.and_then(|data| data.get("ca.crt")).context(err)?;
     let ca_pem = String::from_utf8(ca_bytes.0.clone())?;
     Ok(ca_pem)
 }
@@ -162,7 +163,7 @@ fn generate_ignition(id: &str, endpoint_info: &EndpointInfo) -> IgnitionConfig {
     }
 }
 
-async fn register_handler() -> impl IntoResponse {
+async fn register_handler(State(kube_client): State<Client>) -> impl IntoResponse {
     let id = Uuid::new_v4().to_string();
     let internal_error = |e: anyhow::Error| {
         let code = StatusCode::INTERNAL_SERVER_ERROR;
@@ -172,11 +173,6 @@ async fn register_handler() -> impl IntoResponse {
             "message": format!("{e:#}")
         });
         (code, Json(msg))
-    };
-
-    let kube_client = match Client::try_default().await {
-        Ok(c) => c,
-        Err(e) => return internal_error(e.into()),
     };
 
     // Get the TrustedExecutionCluster to use as owner reference for the Machine
@@ -246,15 +242,19 @@ async fn main() {
 
     let args = Args::parse();
     let endpoint = format!("/{REGISTER_SERVER_RESOURCE}");
-    let app = Router::new().route(&endpoint, get(register_handler));
+    let err = "failed to create Kubernetes client";
+    let app = Router::new()
+        .route(&endpoint, get(register_handler))
+        .with_state(Client::try_default().await.expect(err));
     let addr = SocketAddr::from(([0, 0, 0, 0], args.port));
     let service = app.into_make_service();
-    info!("Starting server on http://{addr}");
 
     let run = if let (Some(cert_path), Some(key_path)) = (args.cert_path, args.key_path) {
         let config = OpenSSLConfig::from_pem_file(cert_path, key_path).expect("invalid PEM files");
+        info!("Starting server on https://{addr}");
         axum_server::bind_openssl(addr, config).serve(service).await
     } else {
+        info!("Starting server on http://{addr}");
         axum_server::bind(addr).serve(service).await
     };
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -682,9 +682,9 @@ impl TestContext {
             .await?;
 
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), &self.test_namespace);
-        wait_for_resource_created(&secrets, REG_SECRET, scaled_timeout(15), 1).await?;
-        wait_for_resource_created(&secrets, TRUSTEE_SECRET, scaled_timeout(15), 1).await?;
-        wait_for_resource_created(&secrets, ATT_REG_SECRET, scaled_timeout(15), 1).await?;
+        wait_for_resource_created(&secrets, REG_SECRET, scaled_timeout(60), 1).await?;
+        wait_for_resource_created(&secrets, TRUSTEE_SECRET, scaled_timeout(60), 1).await?;
+        wait_for_resource_created(&secrets, ATT_REG_SECRET, scaled_timeout(60), 1).await?;
         Ok(())
     }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -851,7 +851,8 @@ impl TestContext {
             rbac_temp_dir.to_str().unwrap(),
             &self.test_name,
             "Applying RBAC",
-            kustomize = true
+            kustomize = true,
+            fssa = true
         );
 
         let manifests_path = Path::new(&self.manifests_dir);


### PR DESCRIPTION
Sourcery comments were created upon already merged PR in testing.

- Set SHELL in Makefile
- Create Client just once in register servers
- Print https when used
- spelling

Drive-by:
- attribution comment
- allow longer creation for cert-manager in tests
- forced server-side apply for RBACs in tests

## Summary by Sourcery

Improve Kubernetes client handling for registration services and stabilize test and build configuration.

Bug Fixes:
- Handle missing ca.crt data in register-server CA retrieval with proper error context.

Enhancements:
- Instantiate the Kubernetes client once in the register and attestation key register servers and pass it via application state.
- Log whether the registration servers are serving over HTTP or HTTPS.
- Document the provenance of the status condition upsert helper function.

Build:
- Set the Makefile SHELL to /bin/bash for more predictable script execution.

Documentation:
- Fix a spelling error in the TLS usage documentation.

Tests:
- Increase timeouts for test secret creation to reduce flakiness.
- Force server-side apply for RBAC resources in tests to avoid client-side apply conflicts.