### PR TITLE
Introduce the reflector to reduce the k8s API calls

### DIFF
--- a/operator/src/attestation_key_register.rs
+++ b/operator/src/attestation_key_register.rs
@@ -15,12 +15,19 @@ use k8s_openapi::apimachinery::pkg::{
 };
 use kube::{
     Api, Client, Resource,
-    api::{ListParams, ObjectList, Patch, PatchParams},
-    runtime::{Controller, controller::Action, finalizer, finalizer::Event, watcher},
+    api::{Patch, PatchParams},
+    runtime::{
+        Controller,
+        controller::Action,
+        finalizer,
+        finalizer::Event,
+        reflector::{self, ObjectRef, Store},
+        watcher,
+    },
 };
 use log::info;
 use serde_json::json;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use trusted_cluster_operator_lib::conditions::ATTESTATION_KEY_MACHINE_APPROVE;
 use trusted_cluster_operator_lib::endpoints::*;
@@ -32,6 +39,46 @@ use operator::{
     ControllerError, TLS_DIR, controller_error_policy, create_or_info_if_exists, read_certificate,
     upsert_condition,
 };
+
+/// Shared context for the three attestation-key controllers.
+/// Stores give local cache access to avoid repeated API-server reads.
+pub struct AkContextData {
+    pub client: Client,
+    pub machine_store: Store<Machine>,
+    pub ak_store: Store<AttestationKey>,
+    pub secret_store: Store<Secret>,
+    pub deployment_store: Store<Deployment>,
+}
+
+impl AkContextData {
+    pub fn new(client: Client) -> Self {
+        let (machine_store, machine_writer) = reflector::store::<Machine>();
+        let (ak_store, ak_writer) = reflector::store::<AttestationKey>();
+        let (secret_store, secret_writer) = reflector::store::<Secret>();
+        let (deployment_store, deployment_writer) = reflector::store::<Deployment>();
+
+        crate::spawn_reflector::<Machine>(machine_writer, client.clone(), "Machine");
+        crate::spawn_reflector::<AttestationKey>(ak_writer, client.clone(), "AttestationKey");
+        crate::spawn_reflector::<Secret>(secret_writer, client.clone(), "Secret");
+        crate::spawn_reflector::<Deployment>(deployment_writer, client.clone(), "Deployment");
+
+        Self {
+            client,
+            machine_store,
+            ak_store,
+            secret_store,
+            deployment_store,
+        }
+    }
+
+    pub async fn sync_caches(&self, timeout: Duration) -> Result<()> {
+        crate::sync_cache(&self.machine_store, "Machine", timeout).await?;
+        crate::sync_cache(&self.ak_store, "AttestationKey", timeout).await?;
+        crate::sync_cache(&self.secret_store, "Secret", timeout).await?;
+        crate::sync_cache(&self.deployment_store, "Deployment", timeout).await?;
+        Ok(())
+    }
+}
 
 const INTERNAL_ATTESTATION_KEY_REGISTER_PORT: i32 = 8001;
 const ATTESTATION_KEY_SECRET_FINALIZER: &str =
@@ -140,21 +187,14 @@ pub async fn create_attestation_key_register_service(
 
 async fn ak_reconcile(
     ak: Arc<AttestationKey>,
-    client: Arc<Client>,
+    ctx: Arc<AkContextData>,
 ) -> Result<Action, ControllerError> {
     let ak_name = ak.metadata.name.clone().unwrap_or_default();
     info!("Attestation Key reconciliation for: {ak_name}");
 
-    let client = Arc::unwrap_or_clone(client);
-    let machines: Api<Machine> = Api::default_namespaced(client.clone());
-    let lp = ListParams::default();
-    let machine_list: ObjectList<Machine> = machines.list(&lp).await.map_err(|e| {
-        eprintln!("Error fetching machine list: {e}");
-        ControllerError::Anyhow(e.into())
-    })?;
-    for machine in &machine_list.items {
+    for machine in ctx.machine_store.state() {
         if ak.spec.uuid.as_ref() == Some(&machine.spec.id) {
-            approve_ak(&ak, machine, client.clone()).await?;
+            approve_ak(&ak, &machine, &ctx).await?;
             return Ok(Action::await_change());
         }
     }
@@ -163,13 +203,12 @@ async fn ak_reconcile(
 
 async fn machine_reconcile(
     machine: Arc<Machine>,
-    client: Arc<Client>,
+    ctx: Arc<AkContextData>,
 ) -> Result<Action, ControllerError> {
     info!(
         "Machine reconciliation for: {}",
         machine.metadata.name.clone().unwrap_or_default()
     );
-    let client = Arc::unwrap_or_clone(client);
 
     // Check if the machine is being deleted
     if machine.metadata.deletion_timestamp.is_some() {
@@ -180,25 +219,20 @@ async fn machine_reconcile(
         return Ok(Action::await_change());
     }
 
-    let aks: Api<AttestationKey> = Api::default_namespaced(client.clone());
-    let lp = ListParams::default();
-    let ak_list: ObjectList<AttestationKey> = aks.list(&lp).await.map_err(|e| {
-        eprintln!("Error fetching attestation key list: {e}");
-        ControllerError::Anyhow(e.into())
-    })?;
-    for ak in ak_list.items {
+    for ak in ctx.ak_store.state() {
         if let Some(ak_uuid) = &ak.spec.uuid
             && *ak_uuid == machine.spec.id
         {
-            approve_ak(&ak, &machine, client.clone()).await?;
+            approve_ak(&ak, &machine, &ctx).await?;
             return Ok(Action::await_change());
         }
     }
     Ok(Action::await_change())
 }
 
-async fn approve_ak(ak: &AttestationKey, machine: &Machine, client: Client) -> Result<()> {
+async fn approve_ak(ak: &AttestationKey, machine: &Machine, ctx: &AkContextData) -> Result<()> {
     let name = ak.metadata.name.clone().unwrap_or_default();
+    let client = &ctx.client;
     let aks: Api<AttestationKey> = Api::default_namespaced(client.clone());
 
     let generation = ak.metadata.generation;
@@ -241,8 +275,11 @@ async fn approve_ak(ak: &AttestationKey, machine: &Machine, client: Client) -> R
     }
 
     let secret_name = name.clone();
-    let secrets: Api<Secret> = Api::default_namespaced(client.clone());
-    let secret_exists = secrets.get(&secret_name).await.is_ok();
+    let ns = client.default_namespace().to_string();
+    let secret_exists = ctx
+        .secret_store
+        .get(&ObjectRef::new(&secret_name).within(&ns))
+        .is_some();
 
     if !secret_exists {
         let public_key_data = ByteString(ak.spec.public_key.as_bytes().to_vec());
@@ -270,7 +307,7 @@ async fn approve_ak(ak: &AttestationKey, machine: &Machine, client: Client) -> R
 
 async fn secret_reconcile(
     secret: Arc<Secret>,
-    client: Arc<Client>,
+    ctx: Arc<AkContextData>,
 ) -> Result<Action, ControllerError> {
     let secret_name = secret.metadata.name.clone().unwrap_or_default();
 
@@ -288,13 +325,13 @@ async fn secret_reconcile(
 
     info!("Secret reconciliation for AttestationKey secret: {secret_name}");
 
-    let secrets: Api<Secret> = Api::default_namespaced(Arc::unwrap_or_clone(client.clone()));
+    let secrets: Api<Secret> = Api::default_namespaced(ctx.client.clone());
+    let ctx = ctx.clone();
     finalizer(&secrets, ATTESTATION_KEY_SECRET_FINALIZER, secret, |ev| async move {
         match ev {
             Event::Apply(_secret) => {
                 // On creation/update, just update the trustee deployment volumes
-                let client = Arc::unwrap_or_clone(client);
-                trustee::update_attestation_keys(client)
+                trustee::update_attestation_keys(&ctx)
                     .await
                     .map(|_| Action::await_change())
                     .map_err(|e| {
@@ -307,21 +344,16 @@ async fn secret_reconcile(
                 info!(
                     "AttestationKey secret {secret_name} is being deleted, updating trustee deployment volumes"
                 );
-                let client = Arc::unwrap_or_clone(client);
                 // Update trustee deployment - secrets with deletion_timestamp will be filtered out
-                match trustee::update_attestation_keys(client).await {
-                    Ok(_) => Ok(Action::await_change()),
-                    Err(e) if e.to_string().contains("not found") => {
-                        info!("Trustee deployment not found during secret cleanup (likely already deleted)");
-                        Ok(Action::await_change())
-                    }
-                    Err(e) => {
+                trustee::update_attestation_keys(&ctx)
+                    .await
+                    .map(|_| Action::await_change())
+                    .map_err(|e| {
                         eprintln!(
                             "Error updating attestation key volumes during secret deletion: {e}"
                         );
-                        Err(finalizer::Error::<ControllerError>::CleanupFailed(e.into()))
-                    }
-                }
+                        finalizer::Error::<ControllerError>::CleanupFailed(e.into())
+                    })
             }
         }
     })
@@ -329,11 +361,11 @@ async fn secret_reconcile(
     .map_err(|e| anyhow!("failed to reconcile attestation key secret: {e}").into())
 }
 
-pub async fn launch_ak_controller(client: Client) {
-    let aks: Api<AttestationKey> = Api::default_namespaced(client.clone());
+pub async fn launch_ak_controller(ctx: Arc<AkContextData>) {
+    let aks: Api<AttestationKey> = Api::default_namespaced(ctx.client.clone());
     tokio::spawn(
         Controller::new(aks, watcher::Config::default())
-            .run(ak_reconcile, controller_error_policy, Arc::new(client))
+            .run(ak_reconcile, controller_error_policy, ctx)
             .for_each(|res| async move {
                 match res {
                     Ok(o) => info!("reconciled {o:?}"),
@@ -343,11 +375,11 @@ pub async fn launch_ak_controller(client: Client) {
     );
 }
 
-pub async fn launch_machine_ak_controller(client: Client) {
-    let machines: Api<Machine> = Api::default_namespaced(client.clone());
+pub async fn launch_machine_ak_controller(ctx: Arc<AkContextData>) {
+    let machines: Api<Machine> = Api::default_namespaced(ctx.client.clone());
     tokio::spawn(
         Controller::new(machines, watcher::Config::default())
-            .run(machine_reconcile, controller_error_policy, Arc::new(client))
+            .run(machine_reconcile, controller_error_policy, ctx)
             .for_each(|res| async move {
                 match res {
                     Ok(o) => info!("machine reconciled for ak approval {o:?}"),
@@ -357,11 +389,11 @@ pub async fn launch_machine_ak_controller(client: Client) {
     );
 }
 
-pub async fn launch_secret_ak_controller(client: Client) {
-    let secrets: Api<Secret> = Api::default_namespaced(client.clone());
+pub async fn launch_secret_ak_controller(ctx: Arc<AkContextData>) {
+    let secrets: Api<Secret> = Api::default_namespaced(ctx.client.clone());
     tokio::spawn(
         Controller::new(secrets, watcher::Config::default())
-            .run(secret_reconcile, controller_error_policy, Arc::new(client))
+            .run(secret_reconcile, controller_error_policy, ctx)
             .for_each(|res| async move {
                 match res {
                     Ok(o) => info!("secret reconciled for ak volumes {o:?}"),

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -9,13 +9,18 @@
 // Use in other crates is not an intended purpose.
 
 use anyhow::Result;
+use futures_util::StreamExt;
 use k8s_openapi::api::core::v1::{Secret, SecretVolumeSource, Volume, VolumeMount};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use k8s_openapi::jiff::Timestamp;
+use kube::Resource;
+use kube::runtime::reflector::{self, Store};
+use kube::runtime::watcher::watcher;
 use kube::{Api, Client, runtime::controller::Action};
 use log::{info, warn};
 use std::fmt::{Debug, Display};
 use std::{sync::Arc, time::Duration};
+use tokio::time::timeout;
 
 // Re-export common functions from the lib
 pub use trusted_cluster_operator_lib::generate_owner_reference;
@@ -87,6 +92,37 @@ pub async fn read_certificate(
         ..Default::default()
     };
     Ok(Some((volume, volume_mount)))
+}
+
+pub fn spawn_reflector<K>(writer: reflector::store::Writer<K>, client: Client, name: &'static str)
+where
+    K: Resource<Scope = k8s_openapi::NamespaceResourceScope>,
+    K: Clone + serde::de::DeserializeOwned + std::fmt::Debug + Send + Sync + 'static,
+    K::DynamicType: Default + Eq + std::hash::Hash + Clone,
+{
+    let watcher = watcher(Api::<K>::default_namespaced(client), Default::default());
+    let reflector = reflector::reflector(writer, watcher).for_each(move |res| async move {
+        if let Err(e) = res {
+            warn!("{name} reflector error: {e}");
+        }
+    });
+    tokio::spawn(reflector);
+}
+
+pub async fn sync_cache<K>(store: &Store<K>, name: &str, sync_timeout: Duration) -> Result<()>
+where
+    K: 'static + Clone + reflector::Lookup,
+    K::DynamicType: Eq + std::hash::Hash + Clone,
+{
+    let err = anyhow::anyhow!(
+        "Timed out after {sync_timeout:?} waiting for {name} cache to sync. \
+         Ensure the CRD is installed and the API server is reachable."
+    );
+    timeout(sync_timeout, store.wait_until_ready())
+        .await
+        .map_err(|_| err)?
+        .map_err(|e| anyhow::anyhow!("Cache writer for {name} was dropped: {e}"))?;
+    Ok(())
 }
 
 // TODO: Port this functionality to kube-rs API.

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -12,6 +12,7 @@ use env_logger::Env;
 use futures_util::StreamExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::runtime::controller::{Action, Controller};
+use kube::runtime::reflector::{self, Store};
 use kube::runtime::watcher;
 use kube::{Api, Client};
 use log::{error, info, warn};
@@ -38,6 +39,29 @@ const COMPONENT_VERSION: &str = "0.2.0";
 /// Default registry
 const TEC_REGISTRY: &str = "quay.io/trusted-execution-clusters";
 
+struct ClusterContext {
+    client: Client,
+    tec_store: Store<TrustedExecutionCluster>,
+}
+
+impl ClusterContext {
+    fn new(client: Client) -> Self {
+        let (tec_store, tec_writer) = reflector::store::<TrustedExecutionCluster>();
+
+        spawn_reflector::<TrustedExecutionCluster>(
+            tec_writer,
+            client.clone(),
+            "TrustedExecutionCluster",
+        );
+
+        Self { client, tec_store }
+    }
+
+    async fn sync_cache_tec(&self, timeout: Duration) -> Result<()> {
+        sync_cache(&self.tec_store, "TrustedExecutionCluster", timeout).await
+    }
+}
+
 fn is_installed(status: Option<TrustedExecutionClusterStatus>) -> bool {
     let chk = |c: &Condition| c.type_ == INSTALLED_CONDITION && c.status == "True";
     status
@@ -48,7 +72,7 @@ fn is_installed(status: Option<TrustedExecutionClusterStatus>) -> bool {
 
 async fn reconcile(
     cluster: Arc<TrustedExecutionCluster>,
-    client: Arc<Client>,
+    ctx: Arc<ClusterContext>,
 ) -> Result<Action, ControllerError> {
     let generation = cluster.metadata.generation;
     let known_address = cluster.spec.public_trustee_addr.is_some();
@@ -61,7 +85,7 @@ async fn reconcile(
     // Update or insert address condition to prevent rebuilding the status object from scratch every time the reconcile is called.
     let _ = upsert_condition(&mut conditions, address_condition);
 
-    let kube_client = Arc::unwrap_or_clone(client);
+    let kube_client = ctx.client.clone();
     let err = "trusted execution cluster had no name";
     let name = &cluster.metadata.name.clone().expect(err);
     let clusters: Api<TrustedExecutionCluster> = Api::default_namespaced(kube_client.clone());
@@ -82,9 +106,7 @@ async fn reconcile(
         return Ok(Action::await_change());
     }
 
-    let list = clusters.list(&Default::default()).await;
-    let cluster_list = list.map_err(Into::<anyhow::Error>::into)?;
-    if cluster_list.items.len() > 1 {
+    if ctx.tec_store.state().len() > 1 {
         let namespace = kube_client.default_namespace();
         warn!(
             "More than one TrustedExecutionCluster found in namespace {namespace}. \
@@ -232,18 +254,40 @@ async fn main() -> Result<()> {
 
     let kube_client = Client::try_default().await?;
     info!("trusted execution clusters operator",);
+
+    const CACHE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
+
+    // Launch controllers that do not depend on reflector caches first.
+    register_server::launch_keygen_controller(kube_client.clone()).await;
+
+    // Spawn reflectors (starts background list-watch immediately).
+    let ak_ctx = Arc::new(attestation_key_register::AkContextData::new(
+        kube_client.clone(),
+    ));
+    let ctx = Arc::new(ClusterContext::new(kube_client.clone()));
+
+    // Best-effort wait for caches; controllers will work with
+    // partially-filled stores if the sync times out.
+    if let Err(e) = ak_ctx.sync_caches(CACHE_SYNC_TIMEOUT).await {
+        warn!("AK cache sync incomplete, controllers will retry: {e}");
+    }
+    if let Err(e) = ctx.sync_cache_tec(CACHE_SYNC_TIMEOUT).await {
+        warn!("TEC cache sync incomplete, controller will retry: {e}");
+    }
+
+    info!("Starting controllers");
+
     let cl: Api<TrustedExecutionCluster> = Api::default_namespaced(kube_client.clone());
 
-    register_server::launch_keygen_controller(kube_client.clone()).await;
-    attestation_key_register::launch_ak_controller(kube_client.clone()).await;
-    attestation_key_register::launch_machine_ak_controller(kube_client.clone()).await;
-    attestation_key_register::launch_secret_ak_controller(kube_client.clone()).await;
+    attestation_key_register::launch_ak_controller(ak_ctx.clone()).await;
+    attestation_key_register::launch_machine_ak_controller(ak_ctx.clone()).await;
+    attestation_key_register::launch_secret_ak_controller(ak_ctx).await;
     reference_values::create_pcrs_config_map(kube_client.clone()).await?;
     reference_values::launch_rv_image_controller(kube_client.clone()).await;
     reference_values::launch_rv_job_controller(kube_client.clone()).await;
 
     Controller::new(cl, watcher::Config::default())
-        .run(reconcile, controller_error_policy, Arc::new(kube_client))
+        .run(reconcile, controller_error_policy, ctx)
         .for_each(controller_info)
         .await;
 
@@ -261,6 +305,25 @@ mod tests {
     use super::*;
     use trusted_cluster_operator_test_utils::mock_client::*;
 
+    fn dummy_cluster_ctx(client: Client) -> ClusterContext {
+        ClusterContext {
+            client,
+            tec_store: reflector::store::<TrustedExecutionCluster>().0,
+        }
+    }
+
+    /// Build a Store pre-populated with two distinct TrustedExecutionCluster objects.
+    fn two_cluster_tec_store() -> Store<TrustedExecutionCluster> {
+        let (store, mut writer) = reflector::store::<TrustedExecutionCluster>();
+        let mut second = dummy_cluster();
+        second.metadata.name = Some("test2".to_string());
+        writer.apply_watcher_event(&watcher::Event::Init);
+        writer.apply_watcher_event(&watcher::Event::InitApply(dummy_cluster()));
+        writer.apply_watcher_event(&watcher::Event::InitApply(second));
+        writer.apply_watcher_event(&watcher::Event::InitDone);
+        store
+    }
+
     #[tokio::test]
     async fn test_reconcile_uninstalling() {
         let clos = async |req: Request<Body>, ctr| match req.method() {
@@ -274,7 +337,7 @@ mod tests {
         count_check!(1, clos, |client| {
             let mut cluster = dummy_cluster();
             cluster.metadata.deletion_timestamp = Some(Time(Timestamp::now()));
-            let result = reconcile(Arc::new(cluster), Arc::new(client)).await;
+            let result = reconcile(Arc::new(cluster), Arc::new(dummy_cluster_ctx(client))).await;
             assert_eq!(result.unwrap(), Action::await_change());
         });
     }
@@ -282,14 +345,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_non_unique() {
         let clos = async |req: Request<_>, ctr| {
-            if ctr == 0 && req.method() == Method::GET {
-                let object_list = ObjectList::<TrustedExecutionCluster> {
-                    items: vec![dummy_cluster(), dummy_cluster()],
-                    types: Default::default(),
-                    metadata: Default::default(),
-                };
-                Ok(serde_json::to_string(&object_list).unwrap())
-            } else if ctr == 1 && req.method() == Method::PATCH {
+            if ctr == 0 && req.method() == Method::PATCH {
                 let body = get_body_string(req).await;
                 assert!(body.contains(NOT_INSTALLED_REASON_NON_UNIQUE));
                 Ok(serde_json::to_string(&dummy_cluster()).unwrap())
@@ -297,9 +353,14 @@ mod tests {
                 panic!("unexpected API interaction: {req:?}, counter {ctr}");
             }
         };
-        count_check!(2, clos, |client| {
+        let store = two_cluster_tec_store();
+        count_check!(1, clos, |client| {
             let cluster = Arc::new(dummy_cluster());
-            let result = reconcile(cluster, Arc::new(client)).await;
+            let ctx = Arc::new(ClusterContext {
+                client,
+                tec_store: store,
+            });
+            let result = reconcile(cluster, ctx).await;
             assert_eq!(result.unwrap(), Action::requeue(Duration::from_secs(60)));
         });
     }
@@ -307,12 +368,17 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_error() {
         let clos = async |req: Request<_>, _| match req {
-            r if r.method() == Method::GET => Err(StatusCode::INTERNAL_SERVER_ERROR),
+            r if r.method() == Method::PATCH => Err(StatusCode::INTERNAL_SERVER_ERROR),
             _ => panic!("unexpected API interaction: {req:?}"),
         };
+        let store = two_cluster_tec_store();
         count_check!(1, clos, |client| {
             let cluster = Arc::new(dummy_cluster());
-            let result = reconcile(cluster, Arc::new(client)).await;
+            let ctx = Arc::new(ClusterContext {
+                client,
+                tec_store: store,
+            });
+            let result = reconcile(cluster, ctx).await;
             assert!(result.is_err());
         });
     }
@@ -351,7 +417,7 @@ mod tests {
             cluster.status = Some(TrustedExecutionClusterStatus {
                 conditions: Some(vec![foreign_condition]),
             });
-            let result = reconcile(Arc::new(cluster), Arc::new(client)).await;
+            let result = reconcile(Arc::new(cluster), Arc::new(dummy_cluster_ctx(client))).await;
             assert_eq!(result.unwrap(), Action::await_change());
         });
     }
@@ -372,23 +438,16 @@ mod tests {
         };
 
         let clos = async |req: Request<Body>, ctr| {
-            if ctr == 0 && req.method() == Method::GET {
-                let object_list = ObjectList::<TrustedExecutionCluster> {
-                    items: vec![dummy_cluster()],
-                    types: Default::default(),
-                    metadata: Default::default(),
-                };
-                Ok(serde_json::to_string(&object_list).unwrap())
-            } else if (0 < ctr && ctr < 9 || ctr == 11) && req.method() == Method::POST {
+            if ctr < 8 && req.method() == Method::POST {
                 Ok(serde_json::to_string(&dummy_cluster()).unwrap())
-            } else if ctr == 9 && req.method() == Method::GET {
+            } else if ctr == 8 && req.method() == Method::GET {
                 let object_list = ObjectList::<ApprovedImage> {
                     items: Vec::new(),
                     types: Default::default(),
                     metadata: Default::default(),
                 };
                 Ok(serde_json::to_string(&object_list).unwrap())
-            } else if ctr == 10 && req.method() == Method::PATCH {
+            } else if ctr == 9 && req.method() == Method::PATCH {
                 let body = req.into_body().collect_bytes().await.unwrap().to_vec();
                 let body = String::from_utf8_lossy(&body);
                 assert!(body.contains("ForeignCondition"),);
@@ -419,8 +478,8 @@ mod tests {
         cluster.status = Some(TrustedExecutionClusterStatus {
             conditions: Some(vec![pre_existing_installed, foreign_condition]),
         });
-        count_check!(11, clos, |client| {
-            let result = reconcile(Arc::new(cluster), Arc::new(client)).await;
+        count_check!(10, clos, |client| {
+            let result = reconcile(Arc::new(cluster), Arc::new(dummy_cluster_ctx(client))).await;
             assert_eq!(result.unwrap(), Action::await_change());
         });
     }
@@ -437,8 +496,9 @@ mod tests {
         count_check!(1, clos1, |client| {
             let mut cluster = dummy_cluster();
             cluster.metadata.deletion_timestamp = Some(Time(Timestamp::now()));
-            let kube_client = Arc::new(client);
-            reconcile(Arc::new(cluster), kube_client).await.unwrap();
+            reconcile(Arc::new(cluster), Arc::new(dummy_cluster_ctx(client)))
+                .await
+                .unwrap();
         });
 
         // Building the uninstalling cluster state.
@@ -470,8 +530,9 @@ mod tests {
             let mut cluster = dummy_cluster();
             cluster.metadata.deletion_timestamp = Some(Time(Timestamp::now()));
             cluster.status = Some(TrustedExecutionClusterStatus { conditions });
-            let kube_client = Arc::new(client);
-            reconcile(Arc::new(cluster), kube_client).await.unwrap();
+            reconcile(Arc::new(cluster), Arc::new(dummy_cluster_ctx(client)))
+                .await
+                .unwrap();
         });
     }
 }

--- a/operator/src/trustee.rs
+++ b/operator/src/trustee.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+use crate::attestation_key_register::AkContextData;
 use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose};
 use chrono::{DateTime, Utc};
@@ -21,6 +22,7 @@ use k8s_openapi::apimachinery::pkg::{
 use kube::{
     Api, Client, Resource,
     api::{ObjectMeta, Patch, PatchParams},
+    runtime::reflector::ObjectRef,
 };
 use log::info;
 use operator::{TLS_DIR, create_or_info_if_exists, read_certificate};
@@ -190,13 +192,12 @@ pub async fn do_mount_secret(client: Client, id: &str, add: bool) -> Result<()> 
     Ok(())
 }
 
-pub async fn update_attestation_keys(client: Client) -> Result<()> {
-    let secrets: Api<Secret> = Api::default_namespaced(client.clone());
-    let secret_list = secrets.list(&Default::default()).await?;
-
-    let ak_secrets: Vec<String> = secret_list
-        .items
-        .iter()
+pub async fn update_attestation_keys(ctx: &AkContextData) -> Result<()> {
+    let client = &ctx.client;
+    let ak_secrets: Vec<String> = ctx
+        .secret_store
+        .state()
+        .into_iter()
         .filter(|secret| {
             // Filter out secrets that are being deleted
             if secret.metadata.deletion_timestamp.is_some() {
@@ -213,8 +214,17 @@ pub async fn update_attestation_keys(client: Client) -> Result<()> {
         .filter_map(|secret| secret.metadata.name.clone())
         .collect();
 
-    let deployments: Api<Deployment> = Api::default_namespaced(client);
-    let deployment = deployments.get(TRUSTEE_DEPLOYMENT).await?;
+    let ns = client.default_namespace().to_string();
+    let Some(deployment) = ctx
+        .deployment_store
+        .get(&ObjectRef::new(TRUSTEE_DEPLOYMENT).within(&ns))
+        .map(std::sync::Arc::unwrap_or_clone)
+    else {
+        // Trustee deployment is not (yet or no longer) present — nothing to patch.
+        info!("{TRUSTEE_DEPLOYMENT} not found in cache, skipping attestation key volume update");
+        return Ok(());
+    };
+    let deployments: Api<Deployment> = Api::default_namespaced(client.clone());
     let err = format!("Deployment {TRUSTEE_DEPLOYMENT} existed, but had no spec");
     let depl_spec = deployment.spec.as_ref().context(err)?;
     let err = format!("Deployment {TRUSTEE_DEPLOYMENT} existed, but had no pod spec");


### PR DESCRIPTION
As requested in [issue 251](https://github.com/trusted-execution-clusters/operator/issues/251).
This PR replaces the direct k8s API calls with reflectors.
This should reduce the API server network latency and consumption of resources on the API server and etcd as well as  risks hitting rate limits (HTTP 429) during heavy workloads.
The cost is increased memory usage as we cache the information from the API server (the CPU for the watcher threads should be reasonably low).
I have not been able to test the cache memory usage as a kind cluster will have a tiny memory signature anyway.

To test the API call reduction I have run the Integration tests on a clean kind cluster and run the command `kubectl get --raw /metrics  | grep apiserver_request_total | grep trusted`, then summed the all calls of all types.
The unmodified operator had a total of 788 calls.
The PR code had a total of 463 calls.

## Summary by Sourcery

Introduce shared reflector-backed caches for custom resources and core objects to reduce direct Kubernetes API usage and wire them into the operator controllers.

New Features:
- Add reflector-based in-memory stores for TrustedExecutionCluster, Machine, AttestationKey, Secret, and Deployment resources and wait for their initial synchronization before starting controllers.

Enhancements:
- Refactor attestation key controllers to share a common context carrying Kubernetes client and reflector stores instead of repeatedly listing resources from the API server.
- Use the reflector-backed TrustedExecutionCluster store in the main reconcile path to detect non-unique clusters without performing a fresh list call.
- Update trustee attestation key volume management to derive secrets and deployment state from reflector caches rather than live API reads.
- Adjust and extend tests to work with pre-populated reflector stores and reduced API interactions, while keeping existing behavior coverage.