### PR TITLE
Test improvments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,11 +209,17 @@ test: crds-rs
 test-release: crds-rs
 	cargo test --workspace --bins --lib --release
 
-integration-tests: generate trusted-cluster-gen crds-rs
-	RUST_LOG=info REGISTRY=$(REGISTRY) TAG=$(TAG) \
-		TRUSTEE_IMAGE=$(TRUSTEE_IMAGE) APPROVED_IMAGE=$(APPROVED_IMAGE) TEST_IMAGE=$(TEST_IMAGE) \
-		cargo test --test trusted_execution_cluster --test attestation \
-		--features virtualization -- --nocapture --test-threads=$(INTEGRATION_TEST_THREADS)
+INTEGRATION_TEST_ENV = RUST_LOG=info REGISTRY=$(REGISTRY) TAG=$(TAG) \
+	TRUSTEE_IMAGE=$(TRUSTEE_IMAGE) APPROVED_IMAGE=$(APPROVED_IMAGE) TEST_IMAGE=$(TEST_IMAGE)
+INTEGRATION_TEST_FLAGS = --features virtualization -- --nocapture --test-threads=$(INTEGRATION_TEST_THREADS)
+
+attestation-tests: generate trusted-cluster-gen crds-rs
+	$(INTEGRATION_TEST_ENV) cargo test --test attestation $(INTEGRATION_TEST_FLAGS)
+
+trusted-execution-cluster-tests: generate trusted-cluster-gen crds-rs
+	$(INTEGRATION_TEST_ENV) cargo test --test trusted_execution_cluster $(INTEGRATION_TEST_FLAGS)
+
+integration-tests: attestation-tests trusted-execution-cluster-tests
 
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -32,6 +32,8 @@ pub mod virt;
 
 use compute_pcrs_lib::Pcr;
 
+const TEST_TIMEOUT_MULTIPLIER_ENV: &str = "TEST_TIMEOUT_MULTIPLIER";
+
 const PLATFORM_ENV: &str = "PLATFORM";
 const CLUSTER_URL_ENV: &str = "CLUSTER_URL";
 const SET_CLUSTER_ERR: &str = "Set $CLUSTER_URL when $PLATFORM is none of: kind, openshift";
@@ -59,6 +61,22 @@ pub fn compare_pcrs(actual: &[Pcr], expected: &[Pcr]) -> bool {
     }
 
     true
+}
+
+fn timeout_multiplier() -> f64 {
+    env::var(TEST_TIMEOUT_MULTIPLIER_ENV)
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|v| v.clamp(0.1, 100.0))
+        .unwrap_or(1.0)
+}
+
+pub fn scaled_timeout(secs: u64) -> u64 {
+    (secs as f64 * timeout_multiplier()).ceil() as u64
+}
+
+pub fn scaled_duration(secs: u64) -> Duration {
+    Duration::from_secs(scaled_timeout(secs))
 }
 
 // Large warning frame, e.g. for paid cloud resources that may not have been shut down correctly
@@ -450,7 +468,7 @@ impl TestContext {
                 tec_api.delete(name, &dp).await?;
 
                 // Wait for the resource to be deleted
-                wait_for_resource_deleted(&tec_api, name, 120, 5).await?;
+                wait_for_resource_deleted(&tec_api, name, scaled_timeout(120), 5).await?;
                 test_info!(
                     &self.test_name,
                     "TrustedExecutionCluster {} has been deleted",
@@ -488,7 +506,13 @@ impl TestContext {
         match namespace_api.get(&self.test_namespace).await {
             Ok(_) => {
                 namespace_api.delete(&self.test_namespace, &dp).await?;
-                wait_for_resource_deleted(&namespace_api, &self.test_namespace, 300, 5).await?;
+                wait_for_resource_deleted(
+                    &namespace_api,
+                    &self.test_namespace,
+                    scaled_timeout(300),
+                    5,
+                )
+                .await?;
                 test_info!(&self.test_name, "Deleted namespace {}", self.test_namespace);
             }
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
@@ -658,9 +682,9 @@ impl TestContext {
             .await?;
 
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), &self.test_namespace);
-        wait_for_resource_created(&secrets, REG_SECRET, 15, 1).await?;
-        wait_for_resource_created(&secrets, TRUSTEE_SECRET, 15, 1).await?;
-        wait_for_resource_created(&secrets, ATT_REG_SECRET, 15, 1).await?;
+        wait_for_resource_created(&secrets, REG_SECRET, scaled_timeout(15), 1).await?;
+        wait_for_resource_created(&secrets, TRUSTEE_SECRET, scaled_timeout(15), 1).await?;
+        wait_for_resource_created(&secrets, ATT_REG_SECRET, scaled_timeout(15), 1).await?;
         Ok(())
     }
 
@@ -910,14 +934,26 @@ impl TestContext {
 
         let deployments_api: Api<Deployment> = Api::namespaced(self.client.clone(), ns);
 
-        self.wait_for_deployment_ready(&deployments_api, "trusted-cluster-operator", 120)
+        self.wait_for_deployment_ready(
+            &deployments_api,
+            "trusted-cluster-operator",
+            scaled_timeout(120),
+        )
+        .await?;
+        self.wait_for_deployment_ready(
+            &deployments_api,
+            REGISTER_SERVER_DEPLOYMENT,
+            scaled_timeout(300),
+        )
+        .await?;
+        self.wait_for_deployment_ready(&deployments_api, TRUSTEE_DEPLOYMENT, scaled_timeout(180))
             .await?;
-        self.wait_for_deployment_ready(&deployments_api, REGISTER_SERVER_DEPLOYMENT, 300)
-            .await?;
-        self.wait_for_deployment_ready(&deployments_api, TRUSTEE_DEPLOYMENT, 180)
-            .await?;
-        self.wait_for_deployment_ready(&deployments_api, ATTESTATION_KEY_REGISTER_DEPLOYMENT, 120)
-            .await?;
+        self.wait_for_deployment_ready(
+            &deployments_api,
+            ATTESTATION_KEY_REGISTER_DEPLOYMENT,
+            scaled_timeout(120),
+        )
+        .await?;
 
         let platform = get_k8s_platform();
         let ak_port = ATTESTATION_KEY_REGISTER_PORT;
@@ -939,7 +975,7 @@ impl TestContext {
 
         let err = format!("image-pcrs ConfigMap in the namespace {ns} not found");
         let poller = Poller::new()
-            .with_timeout(Duration::from_secs(60))
+            .with_timeout(scaled_duration(60))
             .with_interval(Duration::from_secs(5))
             .with_error_message(err);
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,12 @@ make install-kubevirt
 make integration-tests
 ```
 
+To run only one test set:
+```bash
+make attestation-tests
+make trusted-execution-cluster-tests
+```
+
 Each test can also be run independently using cargo test. \
 Before running independent tests, run `make trusted-cluster-gen` to create the default boiler-plate yaml manifests for the TEC and make sure `TRUSTEE_IMAGE`, `APPROVED_IMAGE`, `TEST_IMAGE`, `RUST_LOG`, `REGISTRY`, `TAG` env variables are set.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,7 @@ export REGISTRY=localhost:5000/trusted-execution-clusters
 make push
 make install-kubevirt
 # Set $INTEGRATION_TEST_THREADS to multi-thread (>4G memory per test)
+# Set $TEST_TIMEOUT_MULTIPLIER to increase timeouts on slow systems (e.g. 2, 1.5)
 make integration-tests
 ```
 

--- a/tests/attestation.rs
+++ b/tests/attestation.rs
@@ -45,11 +45,11 @@ impl SingleAttestationContext {
         backend.create_vm().await?;
 
         test_ctx.info(format!("Waiting for VM {vm_name} to reach Running state"));
-        backend.wait_for_running(600).await?;
+        backend.wait_for_running(scaled_timeout(600)).await?;
         test_ctx.info(format!("VM {vm_name} is Running"));
 
         test_ctx.info(format!("Waiting for SSH access to VM {vm_name}"));
-        backend.wait_for_vm_ssh_ready(600).await?;
+        backend.wait_for_vm_ssh_ready(scaled_timeout(600)).await?;
         test_ctx.info("SSH access is ready");
 
         let root_key = backend.get_root_key().await?;
@@ -102,8 +102,8 @@ async fn test_parallel_vm_attestation() -> anyhow::Result<()> {
     // Wait for both VMs to reach Running state in parallel
     test_ctx.info("Waiting for both VMs to reach Running state");
     let (vm1_running, vm2_running) = tokio::join!(
-        backend1.wait_for_running(600),
-        backend2.wait_for_running(600)
+        backend1.wait_for_running(scaled_timeout(600)),
+        backend2.wait_for_running(scaled_timeout(600))
     );
 
     vm1_running?;
@@ -113,8 +113,8 @@ async fn test_parallel_vm_attestation() -> anyhow::Result<()> {
     // Wait for SSH access on both VMs in parallel
     test_ctx.info("Waiting for SSH access on both VMs");
     let (ssh1_ready, ssh2_ready) = tokio::join!(
-        backend1.wait_for_vm_ssh_ready(900),
-        backend2.wait_for_vm_ssh_ready(900)
+        backend1.wait_for_vm_ssh_ready(scaled_timeout(900)),
+        backend2.wait_for_vm_ssh_ready(scaled_timeout(900))
     );
     ssh1_ready?;
     ssh2_ready?;
@@ -169,10 +169,10 @@ async fn test_vm_reboot_attestation() -> anyhow::Result<()> {
         let _reboot_result = att_ctx.backend.ssh_exec("sudo systemctl reboot").await;
 
         test_ctx.info(format!("Waiting for lack of SSH access after reboot {i}"));
-        att_ctx.backend.wait_for_vm_ssh_unavail(30).await?;
+        att_ctx.backend.wait_for_vm_ssh_unavail(scaled_timeout(30)).await?;
 
         test_ctx.info(format!("Waiting for SSH access after reboot {i}"));
-        att_ctx.backend.wait_for_vm_ssh_ready(300).await?;
+        att_ctx.backend.wait_for_vm_ssh_ready(scaled_timeout(300)).await?;
 
         // Verify encrypted root is still present after reboot
         test_ctx.info(format!("Verifying encrypted root after reboot {i}"));
@@ -204,16 +204,16 @@ async fn test_vm_reboot_delete_machine() -> anyhow::Result<()> {
     let list = machines.list(&Default::default()).await?;
     let name = list.items[0].metadata.name.as_ref().unwrap();
     machines.delete(name, &Default::default()).await?;
-    wait_for_resource_deleted(&machines, name, 120, 5).await?;
+    wait_for_resource_deleted(&machines, name, scaled_timeout(120), 5).await?;
 
     test_ctx.info("Performing reboot, expecting missing resource");
     let _reboot_result = att_ctx.backend.ssh_exec("sudo systemctl reboot").await;
 
     test_ctx.info("Waiting for lack of SSH access after reboot");
-    att_ctx.backend.wait_for_vm_ssh_unavail(30).await?;
+    att_ctx.backend.wait_for_vm_ssh_unavail(scaled_timeout(30)).await?;
 
     test_ctx.info("Waiting for SSH access after machine removal");
-    let wait = att_ctx.backend.wait_for_vm_ssh_ready(300).await;
+    let wait = att_ctx.backend.wait_for_vm_ssh_ready(scaled_timeout(300)).await;
     assert!(wait.is_err());
 
     att_ctx.cleanup().await?;
@@ -236,10 +236,10 @@ async fn test_vm_restart_operator_existing() -> anyhow::Result<()> {
     let _reboot_result = att_ctx.backend.ssh_exec("sudo systemctl reboot").await;
 
     test_ctx.info("Waiting for lack of SSH access after reboot");
-    att_ctx.backend.wait_for_vm_ssh_unavail(30).await?;
+    att_ctx.backend.wait_for_vm_ssh_unavail(scaled_timeout(30)).await?;
 
     test_ctx.info("Waiting for SSH access after operator restart & reboot");
-    let wait = att_ctx.backend.wait_for_vm_ssh_ready(300).await;
+    let wait = att_ctx.backend.wait_for_vm_ssh_ready(scaled_timeout(300)).await;
     assert!(wait.is_ok());
 
     att_ctx.cleanup().await?;

--- a/tests/trusted_execution_cluster.rs
+++ b/tests/trusted_execution_cluster.rs
@@ -83,7 +83,7 @@ named_test!(
 
         // Wait for the AttestationKey to be approved (operator should match Machine IP and approve it)
         let poller = Poller::new()
-            .with_timeout(Duration::from_secs(30))
+            .with_timeout(scaled_duration(30))
             .with_interval(Duration::from_millis(500))
             .with_error_message("AttestationKey was not approved".to_string());
 
@@ -125,19 +125,26 @@ named_test!(
         api.delete(TEC_NAME, &dp).await?;
 
         // Wait until it disappears
-        wait_for_resource_deleted(&api, TEC_NAME, 120, 5).await?;
+        wait_for_resource_deleted(&api, TEC_NAME, scaled_timeout(120), 5).await?;
 
         let deployments_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
-        wait_for_resource_deleted(&deployments_api, "trustee-deployment", 120, 1).await?;
-        wait_for_resource_deleted(&deployments_api, "register-server", 120, 1).await?;
+        wait_for_resource_deleted(
+            &deployments_api,
+            "trustee-deployment",
+            scaled_timeout(120),
+            1,
+        )
+        .await?;
+        wait_for_resource_deleted(&deployments_api, "register-server", scaled_timeout(120), 1)
+            .await?;
 
         let images_api: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
-        wait_for_resource_deleted(&images_api, APPROVED_IMAGE_NAME, 120, 1).await?;
+        wait_for_resource_deleted(&images_api, APPROVED_IMAGE_NAME, scaled_timeout(120), 1).await?;
 
-        wait_for_resource_deleted(&machines, &machine_name, 120, 1).await?;
-        wait_for_resource_deleted(&attestation_keys, &ak_name, 120, 1).await?;
+        wait_for_resource_deleted(&machines, &machine_name, scaled_timeout(120), 1).await?;
+        wait_for_resource_deleted(&attestation_keys, &ak_name, scaled_timeout(120), 1).await?;
         let secrets_api: Api<Secret> = Api::namespaced(client.clone(), namespace);
-        wait_for_resource_deleted(&secrets_api, &ak_name, 120, 1).await?;
+        wait_for_resource_deleted(&secrets_api, &ak_name, scaled_timeout(120), 1).await?;
 
         test_ctx.cleanup().await?;
 
@@ -154,7 +161,7 @@ async fn test_image_pcrs_configmap_updates() -> anyhow::Result<()> {
     let configmap_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
 
     let poller = Poller::new()
-        .with_timeout(Duration::from_secs(180))
+        .with_timeout(scaled_duration(180))
         .with_interval(Duration::from_secs(5))
         .with_error_message("image-pcrs ConfigMap not populated with data".to_string());
 
@@ -262,7 +269,7 @@ async fn test_image_disallow() -> anyhow::Result<()> {
 
     let configmap_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     let poller = Poller::new()
-        .with_timeout(Duration::from_secs(180))
+        .with_timeout(scaled_duration(180))
         .with_interval(Duration::from_secs(5))
         .with_error_message("Reference value not removed".to_string());
     poller.poll_async(|| {
@@ -344,7 +351,7 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
     // Poll for the AttestationKey to be approved, have owner reference, and have a Secret created
     let secrets_api: Api<Secret> = Api::namespaced(client.clone(), namespace);
     let poller = Poller::new()
-        .with_timeout(Duration::from_secs(30))
+        .with_timeout(scaled_duration(30))
         .with_interval(Duration::from_millis(500))
         .with_error_message("AttestationKey was not approved with owner reference and secret".to_string());
 
@@ -426,11 +433,11 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
     machines.delete(&machine_name, &dp).await?;
     test_ctx.info(format!("Deleted Machine: {machine_name}"));
 
-    wait_for_resource_deleted(&machines, &machine_name, 120, 1).await?;
+    wait_for_resource_deleted(&machines, &machine_name, scaled_timeout(120), 1).await?;
     test_ctx.info("Machine successfully deleted");
-    wait_for_resource_deleted(&attestation_keys, &ak_name, 120, 1).await?;
+    wait_for_resource_deleted(&attestation_keys, &ak_name, scaled_timeout(120), 1).await?;
     test_ctx.info("AttestationKey successfully deleted");
-    wait_for_resource_deleted(&secrets_api, &ak_name, 120, 1).await?;
+    wait_for_resource_deleted(&secrets_api, &ak_name, scaled_timeout(120), 1).await?;
     test_ctx.info("Secret successfully deleted");
 
     test_ctx.cleanup().await?;
@@ -459,7 +466,7 @@ async fn test_nonexistent_approved_image() -> anyhow::Result<()> {
     }).await?;
 
     let poller = Poller::new()
-        .with_timeout(Duration::from_secs(30))
+        .with_timeout(scaled_duration(30))
         .with_interval(Duration::from_millis(500))
         .with_error_message("ApprovedImage not created".to_string());
     poller.poll_async(|| {


### PR DESCRIPTION
For easier testing I am adding make targets to run the attestation and trusted_execution_cluster seperatly, and an env variable TEST_TIMEOUT_MULTIPLIER that will increase the timeouts of all tests for slower systems.

## Summary by Sourcery

Add configurable test timeout scaling and new make targets for running specific integration test suites.

New Features:
- Introduce TEST_TIMEOUT_MULTIPLIER environment variable to scale timeouts and durations across integration tests.
- Add dedicated make targets for running only attestation or trusted_execution_cluster tests.

Enhancements:
- Refactor existing test timeouts to use shared scaling helpers for durations.
- Document the new timeout multiplier and targeted test make targets in the tests README.