### PR TITLE
tests: Fix cleanup finalizer handling and image reconciliation

### DIFF
--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -268,6 +268,10 @@ async fn image_add_reconcile(
     cluster: Option<TrustedExecutionCluster>,
 ) -> Result<Action> {
     let name = image.metadata.name.as_ref().unwrap();
+    let Some(cluster) = cluster else {
+        info!("No TrustedExecutionCluster found, deferring image processing for {name}");
+        return Ok(Action::requeue(Duration::from_secs(5)));
+    };
     let uid_owns = |uid: &String| {
         let refs = image.metadata.owner_references.as_ref();
         refs.map(|os| os.iter().any(|o| o.uid == *uid))
@@ -277,9 +281,7 @@ async fn image_add_reconcile(
         uid.and_then(uid_owns).unwrap_or(false)
     };
     // Adopt the image by adding TEC as owner reference if not already owned
-    if let Some(cluster) = cluster
-        && !cluster_owns(&cluster)
-    {
+    if !cluster_owns(&cluster) {
         adopt_approved_image(client.clone(), name, &cluster).await?;
     }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -17,6 +17,7 @@ use trusted_cluster_operator_lib::certificates::{
 };
 use trusted_cluster_operator_lib::issuers::{Issuer, IssuerCa, IssuerSpec};
 
+use trusted_cluster_operator_lib::Machine;
 use trusted_cluster_operator_lib::TrustedExecutionCluster;
 use trusted_cluster_operator_lib::openshift_ingresses::Ingress;
 use trusted_cluster_operator_lib::routes::Route;
@@ -404,6 +405,7 @@ impl TestContext {
 
     pub async fn cleanup(&self) -> Result<()> {
         self.delete_trusted_execution_cluster().await?;
+        self.delete_machines().await?;
         self.cleanup_namespace().await?;
         self.cleanup_manifests_dir()?;
         Ok(())
@@ -454,6 +456,25 @@ impl TestContext {
                     "TrustedExecutionCluster {} has been deleted",
                     name
                 );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn delete_machines(&self) -> Result<()> {
+        let machine_api: Api<Machine> = Api::namespaced(self.client.clone(), &self.test_namespace);
+        let machine_list = machine_api.list(&Default::default()).await?;
+
+        for machine in &machine_list.items {
+            if let Some(name) = &machine.metadata.name {
+                test_info!(
+                    &self.test_name,
+                    "Waiting for Machine {} to be deleted",
+                    name
+                );
+                wait_for_resource_deleted(&machine_api, name, 120, 5).await?;
+                test_info!(&self.test_name, "Machine {} has been deleted", name);
             }
         }
 


### PR DESCRIPTION
tests: Wait for Machine deletion before namespace cleanup
fix: Skip ApprovedImage processing when no TEC exists

When test cleanup deletes a TEC with background garbage collection,
the TEC is removed immediately while owned resources are
cascade-deleted asynchronously. This caused two issues:

  - Machine and Secret finalizers blocked namespace deletion because the
  operator pod was terminated before it could process them.
  - image_add_reconcile hit a 404 on the already-deleted trustee-data
  ConfigMap, triggering a 60s error requeue that blocked ApprovedImage
  finalizer cleanup.

Fixed by waiting for Machine deletion before namespace cleanup, and by
skipping image processing when no TEC exists.

## Summary by Sourcery

Ensure test cleanup waits for machine resources to be fully deleted and avoid processing images when no TrustedExecutionCluster is present.

Bug Fixes:
- Prevent namespace cleanup from being blocked by lingering Machine resources during test teardown.
- Avoid image reconciliation errors by deferring ApprovedImage processing when no TrustedExecutionCluster exists.