### PR TITLE
Bump ignition version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ COMPUTE_PCRS_IMAGE=$(REGISTRY)/compute-pcrs:$(TAG)
 REG_SERVER_IMAGE=$(REGISTRY)/registration-server:$(TAG)
 ATTESTATION_KEY_REGISTER_IMAGE=$(REGISTRY)/attestation-key-register:$(TAG)
 TRUSTEE_IMAGE ?= quay.io/trusted-execution-clusters/key-broker-service:v0.17.0
-TEST_IMAGE ?= quay.io/trusted-execution-clusters/fedora-coreos-kubevirt:20260225
+TEST_IMAGE ?= quay.io/trusted-execution-clusters/fedora-coreos-kubevirt:42.20260622
 # tagged as 42.20251012.2.0
 APPROVED_IMAGE ?= quay.io/trusted-execution-clusters/fedora-coreos@sha256:6997f51fd27d1be1b5fc2e6cc3ebf16c17eb94d819b5d44ea8d6cf5f826ee773
 

--- a/docs/design/boot-attestation.md
+++ b/docs/design/boot-attestation.md
@@ -65,7 +65,7 @@ This merge source contacts the registration service, which provides an Ignition 
 ```json
 {
   "ignition": {
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "storage": {
     "luks": [

--- a/examples/ignition-coreos.json
+++ b/examples/ignition-coreos.json
@@ -7,7 +7,7 @@
         }
       ]
     },
-    "version": "3.6.0-experimental"
+    "version": "3.6.0"
   },
   "passwd": {
     "users": [

--- a/examples/vm-coreos-ign.yaml
+++ b/examples/vm-coreos-ign.yaml
@@ -31,7 +31,7 @@ spec:
       volumes:
       - name: containerdisk
         containerDisk:
-          image: "quay.io/trusted-execution-clusters/fedora-coreos-kubevirt:20260225"
+          image: "quay.io/trusted-execution-clusters/fedora-coreos-kubevirt:42.20260622"
           imagePullPolicy: IfNotPresent
       - name: cloudinitdisk
         cloudInitConfigDrive:

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -272,6 +272,11 @@ async fn image_add_reconcile(
         info!("No TrustedExecutionCluster found, deferring image processing for {name}");
         return Ok(Action::requeue(Duration::from_secs(5)));
     };
+    // If the cluster is being deleted, defer the image processing
+    if cluster.metadata.deletion_timestamp.is_some() {
+        info!("TrustedExecutionCluster is being deleted, deferring image processing for {name}");
+        return Ok(Action::requeue(Duration::from_secs(5)));
+    }
     let uid_owns = |uid: &String| {
         let refs = image.metadata.owner_references.as_ref();
         refs.map(|os| os.iter().any(|o| o.uid == *uid))

--- a/register-server/src/main.rs
+++ b/register-server/src/main.rs
@@ -12,7 +12,7 @@ use clevis_pin_trustee_lib::{
     AttestationKey, Config as ClevisConfig, Registration, Server as ClevisServer,
 };
 use env_logger::Env;
-use ignition_config::v3_5::{
+use ignition_config::v3_6::{
     Clevis, ClevisCustom, Config as IgnitionConfig, Filesystem, Luks, Storage,
 };
 use k8s_openapi::api::core::v1::Secret;
@@ -200,18 +200,10 @@ async fn register_handler() -> impl IntoResponse {
     };
 
     let ignition_config = generate_ignition(&id, &endpoint_info);
-    let mut ignition_json = match serde_json::to_value(&ignition_config) {
+    let ignition_json = match serde_json::to_value(&ignition_config) {
         Ok(json) => json,
         Err(e) => return internal_error(e.into()),
     };
-
-    // Overwrite ignition version to 3.6-experimental
-    if let Some(obj) = ignition_json.as_object_mut() {
-        obj.insert(
-            "ignition".to_string(),
-            serde_json::json!({"version": "3.6.0-experimental"}),
-        );
-    }
 
     (StatusCode::OK, Json(ignition_json))
 }

--- a/test_utils/src/virt/mod.rs
+++ b/test_utils/src/virt/mod.rs
@@ -75,14 +75,14 @@ pub fn generate_ssh_key_pair() -> Result<(String, PathBuf)> {
 }
 
 pub async fn generate_ignition(config: &VmConfig) -> Result<serde_json::Value> {
-    use ignition_config::v3_5::*;
+    use ignition_config::v3_6::*;
     let client = config.client.clone();
     let ns = &config.namespace;
     let port = Some(REGISTER_SERVER_PORT);
     let register_server_url = get_cluster_url(client, ns, REGISTER_SERVER_SERVICE, port).await?;
     let root_pem_encoded = utf8_percent_encode(&config.ca_pem, NON_ALPHANUMERIC);
     let ignition = Ignition {
-        version: "3.6.0-experimental".to_string(),
+        version: "3.6.0".to_string(),
         config: Some(IgnitionConfig {
             merge: Some(vec![Resource {
                 source: Some(format!(


### PR DESCRIPTION
1. Test Enhancement: Cluster marked for deletion should never own any new CRD.
2. Upgrade to Ignition v3.6.0 stable and bump FCOS test image
    - Switch ignition_config from v3_5 to v3_6, removing the manual
      version overwrite workaround for 3.6.0-experimental.
    - Bump fedora-coreos-kubevirt test image to 42.20260622, with ignition version 2.26.0, so that it can parse ignition spec version 3.6.0.
    - Updated documentation accordingly.

## Summary by Sourcery

Upgrade ignition configuration version and related test image, and ensure images are not reconciled for clusters being deleted.

Bug Fixes:
- Prevent image reconciliation from assigning ownership to clusters that are marked for deletion.

Enhancements:
- Adopt ignition_config v3.6 with stable 3.6.0 spec handling and remove the previous experimental version override workaround.

Build:
- Update the Fedora CoreOS KubeVirt test image reference to version 42.20260622.

Documentation:
- Refresh ignition-related documentation and example manifests to reference spec version 3.6.0 and the new test image tag.

Tests:
- Align test ignition generation with v3.6.0 spec and the updated CoreOS test image.