### PR TITLE
Dummy change to ensure CI

### DIFF
--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -32,7 +32,7 @@ mod trustee;
 use crate::conditions::*;
 use operator::*;
 
-/// Default tag for Trustee image
+/// The default tag for Trustee image
 const TRUSTEE_VERSION: &str = "v0.17.0";
 /// Default version tag for operator-managed component images
 const COMPONENT_VERSION: &str = "0.2.0";


### PR DESCRIPTION
#288 was accidentally merged before CI completion. Do not merge.

## Summary by Sourcery

Documentation:
- Refine the doc comment describing the default tag used for the Trustee image.