### PR TITLE
Add CONTRIBUTING.md, AGENTS.md

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,4 @@
+---
+description: Core project conventions -- read AGENTS.md in the project root
+alwaysApply: true
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Project objective
+
+See [README](./README.md#trusted-execution-cluster-operator-trusted-cluster-operator).
+
+- **Success looks like**: With the operator deployed, all nodes in the cluster are attested from hardware to software.
+- **Non-goals**: Rely on OpenShift, see the [confidential-clusters](https://github.com/confidential-clusters/operator) downstream.
+
+# Architecture
+
+- Entry points: see [README](./README.md#repository-structure).
+- Integrations
+  - [Trustee](https://github.com/confidential-containers/trustee)
+    - The deployment of Trustee should be restart-stable with respect to configurations, reference values, and brokered keys
+  - [compute-pcrs](https://github.com/trusted-execution-clusters/compute-pcrs)
+  - [clevis-pin-trustee](https://github.com/latchset/clevis-pin-trustee)
+
+# Conventions
+
+- See [CONTRIBUTING](./CONTRIBUTING.md).
+- Use ASCII characters, except where needed for proper nouns
+- Never commit real credentials; use env vars and local `.env` (gitignored) with synthetic values in docs.
+
+# Things that human users of agents should do
+
+and agents should suggest when they detect
+
+- Have a coherent goal per session
+- Read architecture, security-sensitive paths, performance-critical design, ambiguous product trade-offs
+
+# Things agents should do, but can get wrong
+
+- The operator's crate name is `operator`, test_utils's crate name is `trusted-cluster-operator-test-utils`.
+- Use MCPs when available
+  - Prefer the MCP LSP over `grep`
+  - Prefer the k8s LSP over `kubectl`.
+- Reuse, and check for other uses of a similar pattern. When functionality can be moved out of a function for reuse, commit the generalization before the new use.
+- Include lint-compatible code style when writing, not as an afterthought.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+- Use `cargo fmt`. Always perform `make lint clippy` before publishing when code is changed.
+  - Use an extra binding if this saves more than one (formatted) LOC, e.g.
+```rust
+let svc = ATTESTATION_KEY_REGISTER_SERVICE;
+self.create_certificate(svc, ATT_REG_CERT, ATT_REG_SECRET, issuer_name)
+    .await?;
+```
+over
+```rust
+self.create_certificate(
+    ATTESTATION_KEY_REGISTER_SERVICE,
+    ATT_REG_CERT,
+    ATT_REG_SECRET,
+    issuer_name,
+)
+.await?;
+```
+- Use [REUSE](https://reuse.software) comments for new files, or exclude in [REUSE.toml](./REUSE.toml) when not possible.
+- Follow [k8s API conventions](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md)
+  - Use [reflector-backed caches](https://github.com/trusted-execution-clusters/operator/pull/267) where possible
+- Add design documents for large features
+- When functionality is changed, perform `make test`, and [integration test](./tests/README.md) at least with basic attestation.
+- Test with the infrastructure a test needs -- unit with mocked API server, cluster test with a cluster, and attestation test with VMs. Preferably, add a test when
+  - adding a feature
+  - fixing a bug, with a test that you verify isolates this bug
+- For members
+  - Set membership to public so GHA runs integration tests without requiring the ok-to-test label
+  - Merge when you have approval, passing tests, and are happy with your PR.
+
+# Committing
+
+- [Sign commits cryptographically](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---gpg-signkey-id)
+- Limit commit subjects to 50 and messages to 72 characters. Leave an empty line between subject and message.
+- Add small changes to larger PRs in separate commits to ease review burden, but do not add them to already open PRs
+- Commit subjects
+  - Prepend your commit subject with a short focus area. Omit this when making general operator changes. Examples are `tests`, `tests/azure`, `rvs` (reference values)
+  - Most subjects should start with a verb in infinitive form, e.g. `Add reference value removal test`
+- Explain what you did, and why you did it when it isn't obvious
+- Commit trailers
+  - [Sign off commits](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff)
+  - Mark AI use in the commit trailer, such as `Assisted-by: AI`
+- Put separate changes in separate commits, but bisects should stay intact
+  - Linting should pass, so a new definition must be used in the same commit.
+  - When a change requires a change to a test, the changes should be in the same commit. On the contrary, a larger new test can be in a separate commit for easier review.
+
+# AI use
+
+- Do not raise PRs that you do not understand. Review changes with your own eyes before raising.
+- Do not respond to review inquiries with replies that you do not understand
+- Nontrivial use of AI must be included in the commit message trailer

--- a/README.md
+++ b/README.md
@@ -10,14 +10,29 @@ within the cluster.
 
 ## Repository Structure
 
--   `/api`: Defines the `TrustedExecutionCluster` Custom Resource Definition (CRD) and associated CRDs and RBAC definitions in Go. Also contains a program to generate a `TrustedExecutionCluster` CR and associated deployment.
+The operator relies on Rust crates for its functionality.
+
+### Operator components
+
 -   `/operator`: Contains the source code for the Kubernetes operator itself.
 -   `/register-server`: A server that provides Clevis PINs for key retrieval with random UUIDs.
 -   `/attestation-key-register`: A server that accepts attestation key registrations from VMs and creates AttestationKey resources.
 -   `/compute-pcrs`: A program to compute PCR reference values using the [compute-pcrs library](https://github.com/trusted-execution-clusters/compute-pcrs) and insert them into a ConfigMap, run as a Job.
+
+### Other crates
+
 -   `/lib`: Shared Rust definitions, including translated CRDs
+-   `/tests`: Non-unit tests; most rely on a cluster being available. Many of those also rely on a virtualization backend.
+-   `/test_utils`: Operator setup helpers and virtualization backends
+
+### Other components
+
+-   `/docs`, `/examples`
+-   `/api`: Defines the `TrustedExecutionCluster` Custom Resource Definition (CRD) and associated CRDs and RBAC definitions in Go. Also contains a program to generate a `TrustedExecutionCluster` CR and associated deployment.
 -   `/scripts`: Helper scripts for managing a local `kind` development cluster.
 -   `/config`: The default output directory for generated manifests. This directory is not checked into source control.
+-   `/tools`: Tracking tool versions for autoupdates
+-   `/must-gather`: for OpenShift CI
 
 ## Getting Started
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,7 +2,8 @@ version = 1
 
 [[annotations]]
 path = [
-  "README.md",
+  ".cursor/rules/*.mdc",
+  "*.md",
   "Cargo.lock",
   "go.sum",
   "PROJECT",


### PR DESCRIPTION
and links to those from some tools we use, and some README updates with it

## Summary by Sourcery

Document contribution guidelines and agent usage conventions and link them from the main project documentation.

Documentation:
- Add CONTRIBUTING guidelines covering commit practices, testing expectations, and coding style.
- Introduce AGENTS guidance defining project goals, architecture entry points, and expectations for human and AI agent collaboration.
- Update README repository structure to better describe Rust-based operator components and auxiliary crates, and add references to new docs.

Chores:
- Add CLAUDE stub pointing to AGENTS documentation and editor rules configuration under .cursor.