### PR TITLE
gha: Remove `pull_request_target` flow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,10 +5,8 @@
 name: "Integration tests"
 on:
   pull_request:
-    branches:
-      - "main"
-  pull_request_target:
-    types: [labeled]
+    # Default types, plus `labeled` for when `ok-to-test` was added
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - "main"
 permissions:


### PR DESCRIPTION
was added in error, thinking that the `labeled` event could not apply to `pull_request` when it can. This lead to failures because checkout is not enabled by default on `pull_request_target` for security reasons, as happened in #302.

## Summary by Sourcery

CI:
- Update the integration tests GitHub Actions workflow to trigger on labeled pull_request events alongside the standard pull_request event types.