### PR TITLE
Added commit signature verification with verified commit

### DIFF
--- a/.github/workflows/commit-verification.yml
+++ b/.github/workflows/commit-verification.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Chirag Rao <crao@redhat.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: "Commit Verification"
+on:
+  pull_request:
+    branches:
+      - "main"
+  workflow_call:
+permissions:
+  contents: "read"
+
+jobs:
+  verify-commits:
+    name: "Verify commit signatures and authorship"
+    runs-on: " ubuntu-slim"
+    steps:
+      - name: "Verify all PR commits are signed and authored by PR owner"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          errors=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+             -q '
+              .[] | .sha[:12] as $s |
+              (if .commit.verification.verified != true
+               then "::error::Commit \($s) is not signed and/or not verified (\(.commit.verification.reason))"
+               else empty end)
+            ')
+          if [ -n "${errors}" ]; then
+            echo "${errors}"
+            exit 1
+          fi
+          echo "All commits are signed and verified."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-commits:
+    uses: ./.github/workflows/commit-verification.yml
   build:
+    needs: verify-commits
     name: "Build"
     runs-on: "ubuntu-24.04"
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,10 @@ env:
   REGISTRY: localhost:5000/trusted-execution-clusters
 
 jobs:
+  verify-commits:
+    uses: ./.github/workflows/commit-verification.yml
   integration-tests:
+    needs: verify-commits
     name: "KubeVirt integration tests"
     if: >-
       github.event.pull_request.author_association == 'MEMBER' ||

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,10 @@ env:
   ACTIONS_LINTS_TOOLCHAIN: 1.88.0
 
 jobs:
+  verify-commits:
+    uses: ./.github/workflows/commit-verification.yml
   linting:
+    needs: verify-commits
     name: "Lints, pinned toolchain"
     runs-on: "ubuntu-24.04"
     container: "ghcr.io/trusted-execution-clusters/buildroot:fedora"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  verify-commits:
+    uses: ./.github/workflows/commit-verification.yml
   tests-stable:
+    needs: verify-commits
     name: "Tests, stable toolchain"
     runs-on: "ubuntu-24.04"
     container: "ghcr.io/trusted-execution-clusters/buildroot:fedora"
@@ -48,6 +51,7 @@ jobs:
       - name: "cargo test"
         run: cargo test --bins --lib
   tests-release-stable:
+    needs: verify-commits
     name: "Tests (release), stable toolchain"
     runs-on: "ubuntu-24.04"
     container: "ghcr.io/trusted-execution-clusters/buildroot:fedora"
@@ -72,6 +76,7 @@ jobs:
       - name: "cargo test (release)"
         run: cargo test --bins --lib --release
   tests-release-msrv:
+    needs: verify-commits
     name: "Tests (release), minimum supported toolchain"
     runs-on: "ubuntu-24.04"
     container: "ghcr.io/trusted-execution-clusters/buildroot:fedora"
@@ -102,6 +107,7 @@ jobs:
       - name: "cargo test (release)"
         run: cargo test --bins --lib --release
   tests-other-channels:
+    needs: verify-commits
     name: "Tests, unstable toolchain"
     runs-on: "ubuntu-24.04"
     container: "ghcr.io/trusted-execution-clusters/buildroot:fedora"


### PR DESCRIPTION
Have tested with unverified commit

## Summary by Sourcery

Enforce commit signature and authorship verification in all CI workflows before running tests, builds, and linting.

CI:
- Add a reusable commit verification workflow that checks PR commits are GPG/SMIME verified and authored by the PR owner.
- Wire the new commit verification job into Rust, Go, integration test, and lint GitHub Actions workflows as a prerequisite step.