### PR TITLE
dependabot: Fix blocking k8s 1.36

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,15 +27,15 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Block newer versions of k8s until go 1.26 is available in RHEL
+      # Block newer versions of k8s until bump of OpenShift CI
       - dependency-name: "k8s.io/api"
-        versions: [">=0.35"]
+        versions: [">=0.36"]
       - dependency-name: "k8s.io/apimachinery"
-        versions: [">=0.35"]
+        versions: [">=0.36"]
       - dependency-name: "sigs.k8s.io/controller-runtime"
-        versions: [">=0.23"]
+        versions: [">=0.24"]
       - dependency-name: "sigs.k8s.io/controller-tools"
-        versions: [">=0.20"]
+        versions: [">=0.21"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Create KinD cluster"
         run: make cluster-up
       - name: "Build and push images"
-        run: make push
+        run: make DELETE_AFTER_PUSH=true push
       - name: "Install KubeVirt"
         run: make install-kubevirt
       - name: "Pre-pull images"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ and agents should suggest when they detect
 
 - The operator's crate name is `operator`, test_utils's crate name is `trusted-cluster-operator-test-utils`.
 - Use MCPs when available
-  - Prefer the MCP LSP over `grep`
-  - Prefer the k8s LSP over `kubectl`.
+  - Prefer the LSP MCP over `grep`
+  - Prefer the k8s MCP over `kubectl`.
 - Reuse, and check for other uses of a similar pattern. When functionality can be moved out of a function for reuse, commit the generalization before the new use.
 - Include lint-compatible code style when writing, not as an afterthought.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-.PHONY: all build build-tools crds-rs generate manifests cluster-up cluster-down image push install-trustee install clean fmt-check clippy lint test test-release release-tarball prepare-release
+.PHONY: all build build-tools crds-rs generate manifests cluster-up cluster-down \
+	install-trustee install clean fmt-check clippy lint test test-release release-tarball prepare-release \
+	operator-image compute-pcrs-image reg-server-image attestation-key-register-image image \
+	push-operator push-compute-pcrs push-reg-server push-attestation-key-register push \
 
 SHELL := /bin/bash
 
@@ -40,6 +43,7 @@ TAG ?= latest
 # Image tags may use a leading v (e.g. v0.2.1); OLM requires bare semver, without 'v' prefix.
 OLM_VERSION ?= $(patsubst v%,%,$(TAG))
 PUSH_FLAGS ?=
+DELETE_AFTER_PUSH ?= false
 OPERATOR_IMAGE ?= $(REGISTRY)/trusted-cluster-operator:$(TAG)
 COMPUTE_PCRS_IMAGE=$(REGISTRY)/compute-pcrs:$(TAG)
 REG_SERVER_IMAGE=$(REGISTRY)/registration-server:$(TAG)
@@ -127,11 +131,21 @@ attestation-key-register-image:
 
 image: operator-image compute-pcrs-image reg-server-image attestation-key-register-image
 
-push: image
-	$(CONTAINER_CLI) push $(OPERATOR_IMAGE) $(PUSH_FLAGS)
-	$(CONTAINER_CLI) push $(COMPUTE_PCRS_IMAGE) $(PUSH_FLAGS)
-	$(CONTAINER_CLI) push $(REG_SERVER_IMAGE) $(PUSH_FLAGS)
-	$(CONTAINER_CLI) push $(ATTESTATION_KEY_REGISTER_IMAGE) $(PUSH_FLAGS)
+define push-image
+$(CONTAINER_CLI) push $(1) $(PUSH_FLAGS)
+$(if $(filter true,$(DELETE_AFTER_PUSH)),$(CONTAINER_CLI) rmi $(1))
+endef
+
+push-operator: operator-image
+	$(call push-image,$(OPERATOR_IMAGE))
+push-compute-pcrs: compute-pcrs-image
+	$(call push-image,$(COMPUTE_PCRS_IMAGE))
+push-reg-server: reg-server-image
+	$(call push-image,$(REG_SERVER_IMAGE))
+push-attestation-key-register: attestation-key-register-image
+	$(call push-image,$(ATTESTATION_KEY_REGISTER_IMAGE))
+
+push: push-operator push-compute-pcrs push-reg-server push-attestation-key-register
 
 release-tarball: manifests
 	tar -cf trusted-execution-operator-$(TAG).tar config


### PR DESCRIPTION
- Block version we don't want to upgrade to, not the one we're already on or Dependabot ignores it as seen on #311
- Changed the comment: Blocker is no longer RHEL, but still OpenShift CI

## Summary by Sourcery

Build:
- Update Dependabot ignore rules to block k8s.io and sigs.k8s.io packages starting from newer major/minor versions aligned with current Kubernetes 1.36 concerns.