### PR TITLE
Use a read-timeout client for non-watch operations

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,3 +76,14 @@ jobs:
         run: |
           eval $(ssh-agent -s)
           make integration-tests
+      - name: "Gather must-gather"
+        if: always()
+        run: must-gather/gather
+        env:
+          COLLECTION_PATH: must-gather-output
+      - name: "Upload must-gather"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: must-gather-${GITHUB_HEAD_REF}
+          path: must-gather-output/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }
 clevis-pin-trustee-lib = { git = "https://github.com/latchset/clevis-pin-trustee" }
 compute-pcrs-lib = { git = "https://github.com/trusted-execution-clusters/compute-pcrs" }
-env_logger = { version = "0.11.10", default-features = false }
+env_logger = { version = "0.11.10", default-features = false, features = ["humantime"] }
 http = "1.4.2"
 ignition-config = "0.6.1"
 k8s-openapi = { version = "0.28.0", features = ["v1_35", "schemars"] }

--- a/attestation-key-register/src/main.rs
+++ b/attestation-key-register/src/main.rs
@@ -17,7 +17,8 @@ use uuid::Uuid;
 
 use trusted_cluster_operator_lib::endpoints::ATTESTATION_KEY_REGISTER_RESOURCE;
 use trusted_cluster_operator_lib::{
-    generate_owner_reference, get_trusted_execution_cluster, AttestationKey, AttestationKeySpec,
+    generate_owner_reference, get_trusted_execution_cluster, timed_client, AttestationKey,
+    AttestationKeySpec,
 };
 
 #[derive(Parser)]
@@ -131,7 +132,7 @@ async fn main() {
     let args = Args::parse();
     let endpoint = format!("/{ATTESTATION_KEY_REGISTER_RESOURCE}");
     let err = "failed to create Kubernetes client";
-    let client = Client::try_default().await.expect(err);
+    let client = timed_client().await.expect(err);
     let app = Router::new()
         .route(&endpoint, put(handle_registration))
         .with_state(client);

--- a/compute-pcrs/src/main.rs
+++ b/compute-pcrs/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use compute_pcrs_lib::*;
 use k8s_openapi::{api::core::v1::ConfigMap, jiff::Timestamp};
-use kube::{Api, Client};
+use kube::Api;
 use std::{fs::File, io::Read};
 
 use trusted_cluster_operator_lib::{conditions::INSTALLED_REASON, reference_values::*, *};
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
         compute_pcr14(&mokvars),
     ];
 
-    let client = Client::try_default().await?;
+    let client = timed_client().await?;
     let config_maps: Api<ConfigMap> = Api::default_namespaced(client.clone());
 
     let mut image_pcrs_map = config_maps.get(PCR_CONFIG_MAP).await?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,6 +27,31 @@ use anyhow::{Context, Result, anyhow};
 use conditions::*;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, OwnerReference, Time};
 use kube::{Api, Client, Resource};
+use std::time::Duration;
+
+/// Read timeout for non-watch Kubernetes API calls.
+pub const KUBE_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Create a [`Client`] with [`KUBE_READ_TIMEOUT`] applied.
+///
+/// Use this for request/response API calls. For long-lived watch streams, use
+/// [`Client::try_default`] instead so the connection never times out on idle.
+pub async fn timed_client() -> Result<Client> {
+    let mut config = kube::Config::infer().await?;
+    config.read_timeout = Some(KUBE_READ_TIMEOUT);
+    Ok(Client::try_from(config)?)
+}
+
+/// A pair of Kubernetes clients
+///
+/// `client` has a read timeout for request/response API calls.
+/// `watch` has no read timeout, keeping it safe for long-lived watch streams
+/// (Controllers, Reflectors, `await_condition`).
+#[derive(Clone)]
+pub struct KubeClients {
+    pub request_client: Client,
+    pub watch_client: Client,
+}
 
 #[macro_export]
 macro_rules! update_status {

--- a/operator/src/attestation_key_register.rs
+++ b/operator/src/attestation_key_register.rs
@@ -25,7 +25,7 @@ use kube::{
         watcher,
     },
 };
-use log::info;
+use log::{info, warn};
 use serde_json::json;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
@@ -335,7 +335,7 @@ async fn secret_reconcile(
                     .await
                     .map(|_| Action::await_change())
                     .map_err(|e| {
-                        eprintln!("Error updating attestation key volumes on secret apply: {e}");
+                        warn!("Error updating attestation key volumes on secret apply: {e}");
                         finalizer::Error::<ControllerError>::ApplyFailed(e.into())
                     })
             }
@@ -349,9 +349,7 @@ async fn secret_reconcile(
                     .await
                     .map(|_| Action::await_change())
                     .map_err(|e| {
-                        eprintln!(
-                            "Error updating attestation key volumes during secret deletion: {e}"
-                        );
+                        warn!("Error updating attestation key volumes during secret deletion: {e}");
                         finalizer::Error::<ControllerError>::CleanupFailed(e.into())
                     })
             }

--- a/operator/src/attestation_key_register.rs
+++ b/operator/src/attestation_key_register.rs
@@ -213,7 +213,7 @@ async fn machine_reconcile(
     // Check if the machine is being deleted
     if machine.metadata.deletion_timestamp.is_some() {
         info!(
-            "Machine {} is being deleted, updating attestation key volumes",
+            "Machine {} is being deleted, skipping update of attestation key volumes",
             machine.metadata.name.clone().unwrap_or_default()
         );
         return Ok(Action::await_change());

--- a/operator/src/attestation_key_register.rs
+++ b/operator/src/attestation_key_register.rs
@@ -30,8 +30,8 @@ use serde_json::json;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use trusted_cluster_operator_lib::conditions::ATTESTATION_KEY_MACHINE_APPROVE;
-use trusted_cluster_operator_lib::endpoints::*;
-use trusted_cluster_operator_lib::{AttestationKey, AttestationKeyStatus, Machine, update_status};
+use trusted_cluster_operator_lib::{AttestationKey, AttestationKeyStatus, KubeClients, Machine};
+use trusted_cluster_operator_lib::{endpoints::*, update_status};
 
 use crate::conditions::attestation_key_approved_condition;
 use crate::trustee;
@@ -44,6 +44,7 @@ use operator::{
 /// Stores give local cache access to avoid repeated API-server reads.
 pub struct AkContextData {
     pub client: Client,
+    watch_client: Client,
     pub machine_store: Store<Machine>,
     pub ak_store: Store<AttestationKey>,
     pub secret_store: Store<Secret>,
@@ -51,19 +52,21 @@ pub struct AkContextData {
 }
 
 impl AkContextData {
-    pub fn new(client: Client) -> Self {
+    pub fn new(clients: &KubeClients) -> Self {
         let (machine_store, machine_writer) = reflector::store::<Machine>();
         let (ak_store, ak_writer) = reflector::store::<AttestationKey>();
         let (secret_store, secret_writer) = reflector::store::<Secret>();
         let (deployment_store, deployment_writer) = reflector::store::<Deployment>();
 
-        crate::spawn_reflector::<Machine>(machine_writer, client.clone(), "Machine");
-        crate::spawn_reflector::<AttestationKey>(ak_writer, client.clone(), "AttestationKey");
-        crate::spawn_reflector::<Secret>(secret_writer, client.clone(), "Secret");
-        crate::spawn_reflector::<Deployment>(deployment_writer, client.clone(), "Deployment");
+        let watch = &clients.watch_client;
+        crate::spawn_reflector::<Machine>(machine_writer, watch.clone(), "Machine");
+        crate::spawn_reflector::<AttestationKey>(ak_writer, watch.clone(), "AttestationKey");
+        crate::spawn_reflector::<Secret>(secret_writer, watch.clone(), "Secret");
+        crate::spawn_reflector::<Deployment>(deployment_writer, watch.clone(), "Deployment");
 
         Self {
-            client,
+            client: clients.request_client.clone(),
+            watch_client: watch.clone(),
             machine_store,
             ak_store,
             secret_store,
@@ -360,7 +363,7 @@ async fn secret_reconcile(
 }
 
 pub async fn launch_ak_controller(ctx: Arc<AkContextData>) {
-    let aks: Api<AttestationKey> = Api::default_namespaced(ctx.client.clone());
+    let aks: Api<AttestationKey> = Api::default_namespaced(ctx.watch_client.clone());
     tokio::spawn(
         Controller::new(aks, watcher::Config::default())
             .run(ak_reconcile, controller_error_policy, ctx)
@@ -374,7 +377,7 @@ pub async fn launch_ak_controller(ctx: Arc<AkContextData>) {
 }
 
 pub async fn launch_machine_ak_controller(ctx: Arc<AkContextData>) {
-    let machines: Api<Machine> = Api::default_namespaced(ctx.client.clone());
+    let machines: Api<Machine> = Api::default_namespaced(ctx.watch_client.clone());
     tokio::spawn(
         Controller::new(machines, watcher::Config::default())
             .run(machine_reconcile, controller_error_policy, ctx)
@@ -388,7 +391,7 @@ pub async fn launch_machine_ak_controller(ctx: Arc<AkContextData>) {
 }
 
 pub async fn launch_secret_ak_controller(ctx: Arc<AkContextData>) {
-    let secrets: Api<Secret> = Api::default_namespaced(ctx.client.clone());
+    let secrets: Api<Secret> = Api::default_namespaced(ctx.watch_client.clone());
     tokio::spawn(
         Controller::new(secrets, watcher::Config::default())
             .run(secret_reconcile, controller_error_policy, ctx)

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -18,8 +18,10 @@ use kube::{Api, Client};
 use log::{info, warn};
 
 use operator::{generate_owner_reference, upsert_condition};
-use trusted_cluster_operator_lib::{TrustedExecutionCluster, TrustedExecutionClusterStatus};
-use trusted_cluster_operator_lib::{conditions::*, images::*, update_status};
+use trusted_cluster_operator_lib::{
+    KubeClients, TrustedExecutionCluster, TrustedExecutionClusterStatus, conditions::*, images::*,
+    timed_client, update_status,
+};
 
 mod attestation_key_register;
 mod conditions;
@@ -45,15 +47,16 @@ struct ClusterContext {
 }
 
 impl ClusterContext {
-    fn new(client: Client) -> Self {
+    fn new(clients: &KubeClients) -> Self {
         let (tec_store, tec_writer) = reflector::store::<TrustedExecutionCluster>();
 
         spawn_reflector::<TrustedExecutionCluster>(
             tec_writer,
-            client.clone(),
+            clients.watch_client.clone(),
             "TrustedExecutionCluster",
         );
 
+        let client = clients.request_client.clone();
         Self { client, tec_store }
     }
 
@@ -248,19 +251,22 @@ async fn install_attestation_key_register(
 async fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    let kube_client = Client::try_default().await?;
+    let kube_client = timed_client().await?;
+    let watch_client = Client::try_default().await?;
+    let clients = KubeClients {
+        request_client: kube_client.clone(),
+        watch_client: watch_client.clone(),
+    };
     info!("trusted execution clusters operator",);
 
     const CACHE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
 
     // Launch controllers that do not depend on reflector caches first.
-    register_server::launch_keygen_controller(kube_client.clone()).await;
+    register_server::launch_keygen_controller(clients.clone()).await;
 
     // Spawn reflectors (starts background list-watch immediately).
-    let ak_ctx = Arc::new(attestation_key_register::AkContextData::new(
-        kube_client.clone(),
-    ));
-    let ctx = Arc::new(ClusterContext::new(kube_client.clone()));
+    let ak_ctx = Arc::new(attestation_key_register::AkContextData::new(&clients));
+    let ctx = Arc::new(ClusterContext::new(&clients));
 
     // Best-effort wait for caches; controllers will work with
     // partially-filled stores if the sync times out.
@@ -273,14 +279,14 @@ async fn main() -> Result<()> {
 
     info!("Starting controllers");
 
-    let cl: Api<TrustedExecutionCluster> = Api::default_namespaced(kube_client.clone());
+    let cl: Api<TrustedExecutionCluster> = Api::default_namespaced(watch_client);
 
     attestation_key_register::launch_ak_controller(ak_ctx.clone()).await;
     attestation_key_register::launch_machine_ak_controller(ak_ctx.clone()).await;
     attestation_key_register::launch_secret_ak_controller(ak_ctx).await;
     reference_values::create_pcrs_config_map(kube_client.clone()).await?;
-    reference_values::launch_rv_image_controller(kube_client.clone()).await;
-    reference_values::launch_rv_job_controller(kube_client.clone()).await;
+    reference_values::launch_rv_image_controller(clients.clone()).await;
+    reference_values::launch_rv_job_controller(clients).await;
 
     Controller::new(cl, watcher::Config::default())
         .run(reconcile, controller_error_policy, ctx)

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -341,8 +341,11 @@ async fn image_remove_reconcile(
 
 pub async fn launch_rv_image_controller(client: Client) {
     let images: Api<ApprovedImage> = Api::default_namespaced(client.clone());
+    let jobs: Api<Job> = Api::default_namespaced(client.clone());
+    let wc = watcher::Config::default().labels(&format!("{JOB_LABEL_KEY}={PCR_COMMAND_NAME}"));
     tokio::spawn(
         Controller::new(images, Default::default())
+            .owns(jobs, wc)
             .run(image_reconcile, controller_error_policy, Arc::new(client))
             .for_each(controller_info),
     );

--- a/operator/src/reference_values.rs
+++ b/operator/src/reference_values.rs
@@ -133,15 +133,16 @@ async fn job_reconcile(job: Arc<Job>, client: Arc<Client>) -> Result<Action, Con
     Ok(Action::await_change())
 }
 
-pub async fn launch_rv_job_controller(client: Client) {
-    let jobs: Api<Job> = Api::default_namespaced(client.clone());
+pub async fn launch_rv_job_controller(clients: KubeClients) {
+    let jobs: Api<Job> = Api::default_namespaced(clients.watch_client);
     let watcher = watcher::Config {
         label_selector: Some(format!("{JOB_LABEL_KEY}={PCR_COMMAND_NAME}")),
         ..Default::default()
     };
+    let client = Arc::new(clients.request_client);
     tokio::spawn(
         Controller::new(jobs, watcher)
-            .run(job_reconcile, controller_error_policy, Arc::new(client))
+            .run(job_reconcile, controller_error_policy, client)
             .for_each(controller_info),
     );
 }
@@ -339,14 +340,15 @@ async fn image_remove_reconcile(
     Ok(Action::await_change())
 }
 
-pub async fn launch_rv_image_controller(client: Client) {
-    let images: Api<ApprovedImage> = Api::default_namespaced(client.clone());
-    let jobs: Api<Job> = Api::default_namespaced(client.clone());
+pub async fn launch_rv_image_controller(clients: KubeClients) {
+    let images: Api<ApprovedImage> = Api::default_namespaced(clients.watch_client.clone());
+    let jobs: Api<Job> = Api::default_namespaced(clients.watch_client);
     let wc = watcher::Config::default().labels(&format!("{JOB_LABEL_KEY}={PCR_COMMAND_NAME}"));
+    let client = Arc::new(clients.request_client);
     tokio::spawn(
         Controller::new(images, Default::default())
             .owns(jobs, wc)
-            .run(image_reconcile, controller_error_policy, Arc::new(client))
+            .run(image_reconcile, controller_error_policy, client)
             .for_each(controller_info),
     );
 }

--- a/operator/src/register_server.rs
+++ b/operator/src/register_server.rs
@@ -179,6 +179,12 @@ async fn keygen_reconcile(
                             );
                             return Ok(Action::await_change());
                         }
+                        Err(e) => {
+                            let err: anyhow::Error = e.into();
+                            let fin_err =
+                                finalizer::Error::<ControllerError>::CleanupFailed(err.into());
+                            return Err(fin_err);
+                        }
                         _ => {
                             // TEC exists and is not being deleted, proceed with unmount_secret
                         }

--- a/operator/src/register_server.rs
+++ b/operator/src/register_server.rs
@@ -24,7 +24,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::trustee;
 use operator::*;
-use trusted_cluster_operator_lib::{Machine, TrustedExecutionCluster, endpoints::*};
+use trusted_cluster_operator_lib::{KubeClients, Machine, TrustedExecutionCluster, endpoints::*};
 
 /// Finalizer name to discard decryption keys when a machine is deleted
 const MACHINE_FINALIZER: &str = "finalizer.machine.trusted-execution-clusters.io";
@@ -196,11 +196,12 @@ async fn keygen_reconcile(
     .map_err(|e| anyhow!("failed to reconcile on machine: {e}").into())
 }
 
-pub async fn launch_keygen_controller(client: Client) {
-    let machines: Api<Machine> = Api::default_namespaced(client.clone());
+pub async fn launch_keygen_controller(clients: KubeClients) {
+    let machines: Api<Machine> = Api::default_namespaced(clients.watch_client);
+    let client = Arc::new(clients.request_client);
     tokio::spawn(
         Controller::new(machines, Default::default())
-            .run(keygen_reconcile, controller_error_policy, Arc::new(client))
+            .run(keygen_reconcile, controller_error_policy, client)
             .for_each(controller_info),
     );
 }

--- a/register-server/src/main.rs
+++ b/register-server/src/main.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use trusted_cluster_operator_lib::endpoints::*;
 use trusted_cluster_operator_lib::{
-    generate_owner_reference, get_trusted_execution_cluster, Machine, MachineSpec,
+    generate_owner_reference, get_trusted_execution_cluster, timed_client, Machine, MachineSpec,
 };
 
 #[derive(Parser)]
@@ -237,7 +237,7 @@ async fn main() {
     let err = "failed to create Kubernetes client";
     let app = Router::new()
         .route(&endpoint, get(register_handler))
-        .with_state(Client::try_default().await.expect(err));
+        .with_state(timed_client().await.expect(err));
     let addr = SocketAddr::from(([0, 0, 0, 0], args.port));
     let service = app.into_make_service();
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -89,6 +89,11 @@ pub fn scaled_duration(secs: u64) -> Duration {
     Duration::from_secs(scaled_timeout(secs))
 }
 
+fn log_time() -> String {
+    let fmt = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+    fmt.to_string()
+}
+
 // Large warning frame, e.g. for paid cloud resources that may not have been shut down correctly
 pub fn warn_frame(msg: &str) -> String {
     format!("{YELLOW}=== WARNING ===\n{msg}{ANSI_RESET}")
@@ -98,14 +103,14 @@ pub fn warn_frame(msg: &str) -> String {
 macro_rules! test_info {
     ($test_name:expr, $($arg:tt)*) => {{
         const GREEN: &str = "\x1b[32m";
-        println!("{}INFO{}: {}: {}", GREEN, ANSI_RESET, $test_name, format!($($arg)*));
+        println!("{} {}INFO{}: {}: {}", log_time(), GREEN, ANSI_RESET, $test_name, format!($($arg)*));
     }}
 }
 
 #[macro_export]
 macro_rules! test_warn {
     ($test_name:expr, $($arg:tt)*) => {{
-        println!("{YELLOW}WARN{ANSI_RESET}: {}: {}", $test_name, format!($($arg)*));
+        println!("{} {YELLOW}WARN{ANSI_RESET}: {}: {}", log_time(), $test_name, format!($($arg)*));
     }}
 }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -535,7 +535,7 @@ impl TestContext {
 
     pub async fn cleanup(&self) -> Result<()> {
         self.delete_trusted_execution_cluster().await?;
-        let timeout = scaled_duration(60);
+        let timeout = scaled_duration(120);
         let msg = format!("Resources were left behind after {timeout:?}");
         let poller = Poller::new().with_timeout(timeout).with_error_message(msg);
         let chk = || async move {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -26,7 +26,9 @@ use trusted_cluster_operator_lib::conditions::COMMITTED_CONDITION;
 use trusted_cluster_operator_lib::issuers::{Issuer, IssuerCa, IssuerSpec};
 
 use trusted_cluster_operator_lib::{ApprovedImage, ApprovedImageStatus, AttestationKey, Machine};
-use trusted_cluster_operator_lib::{TrustedExecutionCluster, endpoints::*, images::*};
+use trusted_cluster_operator_lib::{
+    KubeClients, TrustedExecutionCluster, endpoints::*, images::*, timed_client,
+};
 
 pub mod timer;
 pub use timer::Poller;
@@ -194,30 +196,30 @@ trait K8sPlatform: Send + Sync {
 
 struct Kind {
     public: bool,
-    client: Client,
+    clients: KubeClients,
     namespace: String,
 }
 struct OpenShift {
-    client: Client,
+    clients: KubeClients,
     namespace: String,
 }
 struct OtherK8s {}
 
-fn get_k8s_platform(client: &Client, namespace: &str) -> Box<dyn K8sPlatform> {
-    let client = client.clone();
+fn get_k8s_platform(clients: &KubeClients, namespace: &str) -> Box<dyn K8sPlatform> {
+    let clients = clients.clone();
     let namespace = namespace.to_string();
     match env::var(PLATFORM_ENV).as_deref().unwrap_or("kind") {
         "kind" => Box::new(Kind {
             public: false,
-            client,
+            clients,
             namespace,
         }),
         "kind_public" => Box::new(Kind {
             public: true,
-            client,
+            clients,
             namespace,
         }),
-        "openshift" => Box::new(OpenShift { client, namespace }),
+        "openshift" => Box::new(OpenShift { clients, namespace }),
         _ => Box::new(OtherK8s {}),
     }
 }
@@ -249,7 +251,8 @@ impl K8sPlatform for Kind {
             port,
             ..Default::default()
         };
-        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
+        let services: Api<Service> =
+            Api::namespaced(self.clients.request_client.clone(), &self.namespace);
         let service = Service {
             metadata: ObjectMeta {
                 name: Some(format!("{service}-forward")),
@@ -284,7 +287,8 @@ enum OpenShiftHost {
 
 impl OpenShift {
     async fn get_url(&self, service: &str) -> OpenShiftHost {
-        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
+        let services: Api<Service> =
+            Api::namespaced(self.clients.request_client.clone(), &self.namespace);
         let Ok(svc) = services.get(service).await else {
             return OpenShiftHost::None;
         };
@@ -313,7 +317,10 @@ impl K8sPlatform for OpenShift {
         cert_name: &str,
         _: &str,
     ) -> Result<()> {
-        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
+        let services: Api<Service> =
+            Api::namespaced(self.clients.request_client.clone(), &self.namespace);
+        let watch_services: Api<Service> =
+            Api::namespaced(self.clients.watch_client.clone(), &self.namespace);
         let pp = Default::default();
         let duration = scaled_duration(120);
         let lb = json!({ "spec": { "type": "LoadBalancer" } });
@@ -333,7 +340,7 @@ impl K8sPlatform for OpenShift {
             let ctx = format!(
                 "waiting for ingress on {service} (attempt {attempt}/{EXPOSE_MAX_ATTEMPTS})"
             );
-            let ingress_ready = await_condition(services.clone(), service, has_ingress);
+            let ingress_ready = await_condition(watch_services.clone(), service, has_ingress);
             match timeout(duration, ingress_ready).await {
                 Err(_) => {
                     last_err = Some(anyhow!(ctx));
@@ -369,7 +376,10 @@ impl K8sPlatform for OpenShift {
             return Err(e);
         }
 
-        let certs: Api<Certificate> = Api::namespaced(self.client.clone(), &self.namespace);
+        let certs: Api<Certificate> =
+            Api::namespaced(self.clients.request_client.clone(), &self.namespace);
+        let watch_certs: Api<Certificate> =
+            Api::namespaced(self.clients.watch_client.clone(), &self.namespace);
         let cert = certs.get(cert_name).await?;
         let old_revision = cert.status.and_then(|st| st.revision).unwrap_or(0);
         let cert_patch = match url {
@@ -397,11 +407,12 @@ impl K8sPlatform for OpenShift {
             cert.and_then(|c| c.status.as_ref().and_then(chk))
                 .unwrap_or(false)
         };
-        let cert_done = await_condition(certs, cert_name, cert_reissued);
+        let cert_done = await_condition(watch_certs, cert_name, cert_reissued);
         let ctx = format!("waiting for cert {cert_name} to have a rev newer than {old_revision}");
         timeout(duration, cert_done).await.context(ctx)??;
 
-        let deployments: Api<Deployment> = Api::namespaced(self.client.clone(), &self.namespace);
+        let deployments: Api<Deployment> =
+            Api::namespaced(self.clients.request_client.clone(), &self.namespace);
         deployments.restart(deployment).await?;
 
         Ok(())
@@ -438,7 +449,7 @@ impl K8sPlatform for OtherK8s {
 }
 
 pub async fn get_cluster_url(
-    client: &Client,
+    clients: &KubeClients,
     namespace: &str,
     service: &str,
     port: Option<i32>,
@@ -450,7 +461,7 @@ pub async fn get_cluster_url(
             None => full_url,
         });
     }
-    get_k8s_platform(client, namespace)
+    get_k8s_platform(clients, namespace)
         .get_cluster_url(service, port)
         .await
 }
@@ -458,7 +469,7 @@ pub async fn get_cluster_url(
 static INIT: Once = Once::new();
 
 pub struct TestContext {
-    client: Client,
+    clients: KubeClients,
     test_namespace: String,
     manifests_dir: String,
     test_name: String,
@@ -471,11 +482,11 @@ impl TestContext {
             let _ = env_logger::builder().is_test(true).try_init();
         });
 
-        let client = setup_test_client().await?;
+        let clients = setup_test_clients().await?;
         let namespace = test_namespace_name();
 
         let ctx = Self {
-            client,
+            clients,
             test_namespace: namespace,
             manifests_dir: String::new(),
             test_name: test_name.to_string(),
@@ -499,7 +510,15 @@ impl TestContext {
     }
 
     pub fn client(&self) -> &Client {
-        &self.client
+        &self.clients.request_client
+    }
+
+    pub fn watch_client(&self) -> &Client {
+        &self.clients.watch_client
+    }
+
+    pub fn clients(&self) -> &KubeClients {
+        &self.clients
     }
 
     pub fn namespace(&self) -> &str {
@@ -537,7 +556,7 @@ impl TestContext {
             "Creating test namespace: {}",
             self.test_namespace
         );
-        let namespace_api: Api<Namespace> = Api::all(self.client.clone());
+        let namespace_api: Api<Namespace> = Api::all(self.clients.request_client.clone());
         let namespace = Namespace {
             metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
                 name: Some(self.test_namespace.clone()),
@@ -558,7 +577,8 @@ impl TestContext {
         K: kube::Resource<DynamicType = (), Scope = k8s_openapi::NamespaceResourceScope> + Clone,
         K: k8s_openapi::serde::de::DeserializeOwned + std::fmt::Debug + Send + 'static,
     {
-        let api: Api<K> = Api::namespaced(self.client.clone(), &self.test_namespace);
+        let api: Api<K> =
+            Api::namespaced(self.clients.request_client.clone(), &self.test_namespace);
         let list = api.list(&Default::default()).await?;
         if let Some(item) = list.items.first() {
             return Err(anyhow!("Resource still present: {item:?}"));
@@ -568,7 +588,7 @@ impl TestContext {
 
     async fn delete_trusted_execution_cluster(&self) -> Result<()> {
         let tec_api: Api<TrustedExecutionCluster> =
-            Api::namespaced(self.client.clone(), &self.test_namespace);
+            Api::namespaced(self.clients.request_client.clone(), &self.test_namespace);
         let dp = DeleteParams::default();
 
         let tec_list = tec_api.list(&Default::default()).await?;
@@ -596,14 +616,15 @@ impl TestContext {
     }
 
     async fn cleanup_namespace(&self) -> Result<()> {
-        let namespace_api: Api<Namespace> = Api::all(self.client.clone());
+        let namespace_api: Api<Namespace> = Api::all(self.clients.request_client.clone());
+        let watch_namespaces: Api<Namespace> = Api::all(self.clients.watch_client.clone());
         let dp = DeleteParams::default();
 
         match namespace_api.get(&self.test_namespace).await {
             Ok(_) => {
                 namespace_api.delete(&self.test_namespace, &dp).await?;
                 let timeout = scaled_timeout(300);
-                wait_for_resource_deleted(&namespace_api, &self.test_namespace, timeout).await?;
+                wait_for_resource_deleted(&watch_namespaces, &self.test_namespace, timeout).await?;
                 test_info!(&self.test_name, "Deleted namespace {}", self.test_namespace);
             }
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
@@ -646,8 +667,8 @@ impl TestContext {
         issuer_name: &str,
     ) -> Result<()> {
         let ns = &self.test_namespace;
-        let domain = get_cluster_url(&self.client, ns, service_name, None).await?;
-        let certs: Api<Certificate> = Api::namespaced(self.client.clone(), ns);
+        let domain = get_cluster_url(&self.clients, ns, service_name, None).await?;
+        let certs: Api<Certificate> = Api::namespaced(self.clients.request_client.clone(), ns);
         let cert = Certificate {
             metadata: ObjectMeta {
                 name: Some(cert_name.to_string()),
@@ -682,7 +703,7 @@ impl TestContext {
             },
             ..Default::default()
         };
-        let issuers: Api<Issuer> = Api::namespaced(self.client.clone(), ns);
+        let issuers: Api<Issuer> = Api::namespaced(self.clients.request_client.clone(), ns);
         issuers.create(&Default::default(), &root_issuer).await?;
         let root_cert = Certificate {
             metadata: ObjectMeta {
@@ -701,7 +722,7 @@ impl TestContext {
             },
             ..Default::default()
         };
-        let certs: Api<Certificate> = Api::namespaced(self.client.clone(), ns);
+        let certs: Api<Certificate> = Api::namespaced(self.clients.request_client.clone(), ns);
         certs.create(&Default::default(), &root_cert).await?;
         let issuer_name = "issuer";
         let issuer = Issuer {
@@ -729,7 +750,8 @@ impl TestContext {
         self.create_certificate(svc, ATT_REG_CERT, ATT_REG_SECRET, issuer_name)
             .await?;
 
-        let secrets: Api<Secret> = Api::namespaced(self.client.clone(), &self.test_namespace);
+        let secrets: Api<Secret> =
+            Api::namespaced(self.clients.request_client.clone(), &self.test_namespace);
         for secret in [REG_SECRET, TRUSTEE_SECRET, ATT_REG_SECRET] {
             wait_for_resource_created(&secrets, secret, scaled_timeout(60)).await?;
         }
@@ -876,7 +898,7 @@ impl TestContext {
         std::fs::write(&le_rb_dst, le_rb_content)?;
 
         test_info!(&self.test_name, "Preparing RBAC kustomization");
-        let platform = get_k8s_platform(&self.client, &self.test_namespace);
+        let platform = get_k8s_platform(&self.clients, &self.test_namespace);
         let kustomization_src = workspace_root.join("config/rbac/kustomization.yaml.in");
         let kustomization_content = std::fs::read_to_string(&kustomization_src)?;
         let mut kustom_value: serde_yaml::Value = serde_yaml::from_str(&kustomization_content)?;
@@ -942,7 +964,7 @@ impl TestContext {
         );
 
         if get_virt_provider()? == VirtProvider::Kubevirt {
-            let platform = get_k8s_platform(&self.client, &self.test_namespace);
+            let platform = get_k8s_platform(&self.clients, &self.test_namespace);
             let port = ATTESTATION_KEY_REGISTER_PORT;
             let address = platform.get_cluster_url(ATTESTATION_KEY_REGISTER_SERVICE, Some(port));
             spec_map.insert(
@@ -976,7 +998,7 @@ impl TestContext {
             depl.and_then(chk).unwrap_or(false)
         };
 
-        let depls: Api<Deployment> = Api::namespaced(self.client.clone(), ns);
+        let depls: Api<Deployment> = Api::namespaced(self.clients.watch_client.clone(), ns);
         for depl in [
             "trusted-cluster-operator",
             REGISTER_SERVER_DEPLOYMENT,
@@ -991,14 +1013,14 @@ impl TestContext {
         }
 
         let svc = ATTESTATION_KEY_REGISTER_SERVICE;
-        let services: Api<Service> = Api::namespaced(self.client.clone(), ns);
+        let services: Api<Service> = Api::namespaced(self.clients.watch_client.clone(), ns);
         for svc in [REGISTER_SERVER_SERVICE, TRUSTEE_SERVICE, svc] {
             let done = await_condition(services.clone(), svc, |s: Option<&Service>| s.is_some());
             let ctx = format!("waiting for service {svc} to exist");
             timeout(scaled_duration(60), done).await.context(ctx)??;
         }
 
-        let platform = get_k8s_platform(&self.client, &self.test_namespace);
+        let platform = get_k8s_platform(&self.clients, &self.test_namespace);
         let svc = REGISTER_SERVER_SERVICE;
         let depl = REGISTER_SERVER_DEPLOYMENT;
         let test_name = &self.test_name;
@@ -1010,9 +1032,10 @@ impl TestContext {
         let depl = ATTESTATION_KEY_REGISTER_DEPLOYMENT;
         platform.expose(svc, depl, ATT_REG_CERT, test_name).await?;
 
-        let tecs: Api<TrustedExecutionCluster> = Api::namespaced(self.client.clone(), ns);
+        let tecs: Api<TrustedExecutionCluster> =
+            Api::namespaced(self.clients.request_client.clone(), ns);
         let trustee_addr =
-            get_cluster_url(&self.client, ns, TRUSTEE_SERVICE, Some(TRUSTEE_PORT)).await?;
+            get_cluster_url(&self.clients, ns, TRUSTEE_SERVICE, Some(TRUSTEE_PORT)).await?;
         let json = json!({
             "spec": {
                 "publicTrusteeAddr": trustee_addr
@@ -1028,12 +1051,13 @@ impl TestContext {
             &self.test_name,
             "Waiting for image-pcrs ConfigMap to be created"
         );
-        let configmap_api: Api<ConfigMap> = Api::namespaced(self.client.clone(), ns);
+        let configmap_api: Api<ConfigMap> =
+            Api::namespaced(self.clients.request_client.clone(), ns);
         wait_for_resource_created(&configmap_api, "image-pcrs", scaled_timeout(60)).await?;
 
         let info = format!("Waiting for ApprovedImage {APPROVED_IMAGE_NAME} to be Committed");
         test_info!(&self.test_name, "{info}");
-        let images: Api<ApprovedImage> = Api::namespaced(self.client.clone(), ns);
+        let images: Api<ApprovedImage> = Api::namespaced(self.clients.watch_client.clone(), ns);
         let image_ready = |img: Option<&ApprovedImage>| {
             let chk_cond = |c: &Condition| c.type_ == COMMITTED_CONDITION && c.status == "True";
             let chk_status =
@@ -1078,9 +1102,13 @@ macro_rules! setup {
     (delayed_approved_image) => {{ $crate::TestContext::new(TEST_NAME, true) }};
 }
 
-async fn setup_test_client() -> Result<Client> {
-    let client = Client::try_default().await?;
-    Ok(client)
+async fn setup_test_clients() -> Result<KubeClients> {
+    let request_client = timed_client().await?;
+    let watch_client = Client::try_default().await?;
+    Ok(KubeClients {
+        request_client,
+        watch_client,
+    })
 }
 
 fn test_namespace_name() -> String {

--- a/test_utils/src/virt/kubevirt.rs
+++ b/test_utils/src/virt/kubevirt.rs
@@ -36,7 +36,8 @@ impl VmBackend for KubevirtBackend {
             ..Default::default()
         };
 
-        let secrets: Api<Secret> = Api::namespaced(self.0.client.clone(), &self.0.namespace);
+        let secrets: Api<Secret> =
+            Api::namespaced(self.0.clients.request_client.clone(), &self.0.namespace);
         secrets.create(&Default::default(), &secret).await?;
 
         let vm = VirtualMachine {
@@ -134,14 +135,16 @@ impl VmBackend for KubevirtBackend {
             ..Default::default()
         };
 
-        let vms: Api<VirtualMachine> = Api::namespaced(self.0.client.clone(), &self.0.namespace);
+        let vms: Api<VirtualMachine> =
+            Api::namespaced(self.0.clients.request_client.clone(), &self.0.namespace);
         vms.create(&Default::default(), &vm).await?;
 
         Ok(())
     }
 
     async fn wait_for_running(&self, timeout_secs: u64) -> Result<()> {
-        let api: Api<VirtualMachine> = Api::namespaced(self.0.client.clone(), &self.0.namespace);
+        let api: Api<VirtualMachine> =
+            Api::namespaced(self.0.clients.watch_client.clone(), &self.0.namespace);
         let machine_running = |m: Option<&VirtualMachine>| {
             let status = m.as_ref().and_then(|m| m.status.as_ref());
             let print_status = status.and_then(|s| s.printable_status.as_ref());
@@ -180,7 +183,8 @@ impl VmBackend for KubevirtBackend {
         }
 
         // Use the UUID to get the secret (secrets are named with just the UUID)
-        let secrets: Api<Secret> = Api::namespaced(self.0.client.clone(), &self.0.namespace);
+        let secrets: Api<Secret> =
+            Api::namespaced(self.0.clients.request_client.clone(), &self.0.namespace);
         let secret = secrets
             .get(uuid)
             .await

--- a/test_utils/src/virt/mod.rs
+++ b/test_utils/src/virt/mod.rs
@@ -9,7 +9,7 @@ pub mod kubevirt;
 use anyhow::{Result, anyhow};
 use clevis_pin_trustee_lib::Key as ClevisKey;
 use k8s_openapi::api::core::v1::Secret;
-use kube::{Api, Client};
+use kube::Api;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use std::{env, path::PathBuf, time::Duration};
 use tokio::process::Command;
@@ -22,7 +22,7 @@ use crate::{ROOT_SECRET, VirtProvider, get_cluster_url, get_env, get_virt_provid
 
 #[derive(Clone)]
 pub struct VmConfig {
-    pub client: Client,
+    pub clients: KubeClients,
     pub namespace: String,
     pub vm_name: String,
     pub ssh_public_key: String,
@@ -76,10 +76,10 @@ pub fn generate_ssh_key_pair() -> Result<(String, PathBuf)> {
 
 pub async fn generate_ignition(config: &VmConfig) -> Result<serde_json::Value> {
     use ignition_config::v3_6::*;
-    let client = config.client.clone();
     let ns = &config.namespace;
     let port = Some(REGISTER_SERVER_PORT);
-    let register_server_url = get_cluster_url(&client, ns, REGISTER_SERVER_SERVICE, port).await?;
+    let register_server_url =
+        get_cluster_url(&config.clients, ns, REGISTER_SERVER_SERVICE, port).await?;
     let root_pem_encoded = utf8_percent_encode(&config.ca_pem, NON_ALPHANUMERIC);
     let ignition = Ignition {
         version: "3.6.0".to_string(),
@@ -148,11 +148,11 @@ pub async fn ssh_exec(command: &str) -> Result<String> {
 }
 
 pub async fn create_backend(
-    client: Client,
+    clients: KubeClients,
     namespace: &str,
     vm_name: &str,
 ) -> Result<Box<dyn VmBackend>> {
-    let secrets: Api<Secret> = Api::namespaced(client.clone(), namespace);
+    let secrets: Api<Secret> = Api::namespaced(clients.request_client.clone(), namespace);
     let root_secret = secrets.get(ROOT_SECRET).await?;
     let root_secret_data = root_secret.data.unwrap();
     let ca_pem_bytes = root_secret_data.get("ca.crt").unwrap();
@@ -162,7 +162,7 @@ pub async fn create_backend(
     let (public_key, key_path) = generate_ssh_key_pair()?;
     let image = get_env("TEST_IMAGE")?;
     let config = VmConfig {
-        client,
+        clients,
         namespace: namespace.to_string(),
         vm_name: vm_name.to_string(),
         ssh_public_key: public_key,

--- a/tests/attestation.rs
+++ b/tests/attestation.rs
@@ -36,10 +36,10 @@ impl SingleAttestationContext {
 
 impl SingleAttestationContext {
     async fn new(vm_name: &str, test_ctx: &TestContext) -> Result<Self> {
-        let client = test_ctx.client();
         let namespace = test_ctx.namespace();
 
-        let backend = virt::create_backend(client.clone(), namespace, vm_name).await?;
+        let backend =
+            virt::create_backend(test_ctx.clients().clone(), namespace, vm_name).await?;
 
         test_ctx.info(format!("Creating VM: {vm_name}"));
         backend.create_vm().await?;
@@ -83,15 +83,15 @@ async fn test_attestation() -> anyhow::Result<()> {
 virt_test! {
 async fn test_parallel_vm_attestation() -> anyhow::Result<()> {
     let test_ctx = setup!().await?;
-    let client = test_ctx.client();
+    let clients = test_ctx.clients().clone();
     let namespace = test_ctx.namespace();
     test_ctx.info("Testing parallel VM attestation - launching 2 VMs simultaneously");
 
     // Launch both VMs in parallel
     let vm1_name = "test-coreos-vm1";
     let vm2_name = "test-coreos-vm2";
-    let backend1 = virt::create_backend(client.clone(), namespace, vm1_name).await?;
-    let backend2 = virt::create_backend(client.clone(), namespace, vm2_name).await?;
+    let backend1 = virt::create_backend(clients.clone(), namespace, vm1_name).await?;
+    let backend2 = virt::create_backend(clients.clone(), namespace, vm2_name).await?;
 
     test_ctx.info("Creating VM1 and VM2 in parallel");
     let (vm1_result, vm2_result) = tokio::join!(backend1.create_vm(), backend2.create_vm());
@@ -198,10 +198,12 @@ async fn test_vm_reboot_delete_machine() -> anyhow::Result<()> {
     let att_ctx = SingleAttestationContext::new(vm_name, &test_ctx).await?;
 
     let machines: Api<Machine> = Api::namespaced(test_ctx.client().clone(), test_ctx.namespace());
+    let watch_machines: Api<Machine> =
+        Api::namespaced(test_ctx.watch_client().clone(), test_ctx.namespace());
     let list = machines.list(&Default::default()).await?;
     let name = list.items[0].metadata.name.as_ref().unwrap();
     machines.delete(name, &Default::default()).await?;
-    wait_for_resource_deleted(&machines, name, scaled_timeout(120)).await?;
+    wait_for_resource_deleted(&watch_machines, name, scaled_timeout(120)).await?;
 
     test_ctx.info("Performing reboot, expecting missing resource");
     let boot_id = att_ctx.backend.get_boot_id().await?;

--- a/tests/trusted_execution_cluster.rs
+++ b/tests/trusted_execution_cluster.rs
@@ -36,6 +36,7 @@ named_test!(
     async fn test_trusted_execution_cluster_uninstall() -> anyhow::Result<()> {
         let test_ctx = setup!().await?;
         let client = test_ctx.client();
+        let watch = test_ctx.watch_client();
         let namespace = test_ctx.namespace();
 
         let tec_api: Api<TrustedExecutionCluster> = Api::namespaced(client.clone(), namespace);
@@ -91,7 +92,8 @@ named_test!(
         ));
 
         // Wait for the AttestationKey to be approved (operator should match Machine IP and approve it)
-        let done = await_condition(attestation_keys.clone(), &ak_name, ak_approved);
+        let watch_aks: Api<AttestationKey> = Api::namespaced(watch.clone(), namespace);
+        let done = await_condition(watch_aks.clone(), &ak_name, ak_approved);
         let ctx = format!("waiting for AttestationKey {ak_name} to be approved");
         timeout(scaled_duration(30), done).await.context(ctx)??;
 
@@ -103,20 +105,22 @@ named_test!(
         api.delete(TEC_NAME, &dp).await?;
 
         // Wait until it disappears
-        wait_for_resource_deleted(&api, TEC_NAME, scaled_timeout(120)).await?;
+        let watch_tec: Api<TrustedExecutionCluster> = Api::namespaced(watch.clone(), namespace);
+        wait_for_resource_deleted(&watch_tec, TEC_NAME, scaled_timeout(120)).await?;
 
-        let deployments_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
+        let watch_depls: Api<Deployment> = Api::namespaced(watch.clone(), namespace);
         let timeout = scaled_timeout(120);
-        wait_for_resource_deleted(&deployments_api, TRUSTEE_DEPLOYMENT, timeout).await?;
-        wait_for_resource_deleted(&deployments_api, REGISTER_SERVER_DEPLOYMENT, timeout).await?;
+        wait_for_resource_deleted(&watch_depls, TRUSTEE_DEPLOYMENT, timeout).await?;
+        wait_for_resource_deleted(&watch_depls, REGISTER_SERVER_DEPLOYMENT, timeout).await?;
 
-        let images_api: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
-        wait_for_resource_deleted(&images_api, APPROVED_IMAGE_NAME, scaled_timeout(120)).await?;
+        let watch_images: Api<ApprovedImage> = Api::namespaced(watch.clone(), namespace);
+        wait_for_resource_deleted(&watch_images, APPROVED_IMAGE_NAME, scaled_timeout(120)).await?;
 
-        wait_for_resource_deleted(&machines, &machine_name, scaled_timeout(120)).await?;
-        wait_for_resource_deleted(&attestation_keys, &ak_name, scaled_timeout(120)).await?;
-        let secrets_api: Api<Secret> = Api::namespaced(client.clone(), namespace);
-        wait_for_resource_deleted(&secrets_api, &ak_name, scaled_timeout(120)).await?;
+        let watch_machines: Api<Machine> = Api::namespaced(watch.clone(), namespace);
+        wait_for_resource_deleted(&watch_machines, &machine_name, scaled_timeout(120)).await?;
+        wait_for_resource_deleted(&watch_aks, &ak_name, scaled_timeout(120)).await?;
+        let watch_secrets: Api<Secret> = Api::namespaced(watch.clone(), namespace);
+        wait_for_resource_deleted(&watch_secrets, &ak_name, scaled_timeout(120)).await?;
 
         test_ctx.cleanup().await?;
 
@@ -128,9 +132,10 @@ named_test! {
 async fn test_image_pcrs_configmap_updates() -> anyhow::Result<()> {
     let test_ctx = setup!().await?;
     let client = test_ctx.client();
+    let watch = test_ctx.watch_client();
     let namespace = test_ctx.namespace();
 
-    let configmap_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    let configmap_api: Api<ConfigMap> = Api::namespaced(watch.clone(), namespace);
     let populated = |cm: Option<&ConfigMap>| {
         let data = cm.and_then(|cm| cm.data.as_ref());
         let json = data.and_then(|data| data.get("image-pcrs.json"));
@@ -141,7 +146,8 @@ async fn test_image_pcrs_configmap_updates() -> anyhow::Result<()> {
     let ctx = "waiting for ConfigMap image-pcrs to be populated";
     timeout(scaled_duration(180), done).await.context(ctx)??;
 
-    let image_pcrs_cm = configmap_api.get("image-pcrs").await?;
+    let cm_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    let image_pcrs_cm = cm_api.get("image-pcrs").await?;
     assert_eq!(image_pcrs_cm.metadata.name.as_deref(), Some("image-pcrs"));
 
     let data = image_pcrs_cm.data.as_ref()
@@ -219,12 +225,13 @@ named_test! {
 async fn test_image_disallow() -> anyhow::Result<()> {
     let test_ctx = setup!().await?;
     let client = test_ctx.client();
+    let watch = test_ctx.watch_client();
     let namespace = test_ctx.namespace();
 
     let images: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
     images.delete(APPROVED_IMAGE_NAME, &DeleteParams::default()).await?;
 
-    let configmap_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    let configmap_api: Api<ConfigMap> = Api::namespaced(watch.clone(), namespace);
     let chk_removed = |cm: Option<&ConfigMap>| {
         let data = cm.and_then(|cm| cm.data.as_ref());
         let json = data.and_then(|data| data.get(RV_JSON_KEY));
@@ -243,6 +250,7 @@ named_test! {
 async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
     let test_ctx = setup!().await?;
     let client = test_ctx.client();
+    let watch = test_ctx.watch_client();
     let namespace = test_ctx.namespace();
 
     let tec_api: Api<TrustedExecutionCluster> = Api::namespaced(client.clone(), namespace);
@@ -297,7 +305,8 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
     ));
 
     // Timeout for the AttestationKey to be approved, have owner reference, and have a Secret created
-    let approved = await_condition(attestation_keys.clone(), &ak_name, ak_approved);
+    let watch_aks: Api<AttestationKey> = Api::namespaced(watch.clone(), namespace);
+    let approved = await_condition(watch_aks.clone(), &ak_name, ak_approved);
     let ctx = format!("waiting for AttestationKey {ak_name} to be approved");
     timeout(scaled_duration(30), approved).await.context(ctx)??;
     let chk_machine_owner = |ak: Option<&AttestationKey>| {
@@ -305,16 +314,16 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
         let refs = ak.and_then(|ak| ak.metadata.owner_references.as_ref());
         refs.map(|refs| refs.iter().any(chk_owner)).unwrap_or(false)
     };
-    let has_machine_owner = await_condition(attestation_keys.clone(), &ak_name, chk_machine_owner);
+    let has_machine_owner = await_condition(watch_aks.clone(), &ak_name, chk_machine_owner);
     let ctx = format!("waiting for AttestationKey {ak_name} to be owned by Machine {machine_name}");
     timeout(scaled_duration(30), has_machine_owner).await.context(ctx)??;
-    let secrets_api: Api<Secret> = Api::namespaced(client.clone(), namespace);
+    let secrets: Api<Secret> = Api::namespaced(watch.clone(), namespace);
     let chk_ak_owner = |secret: Option<&Secret>| {
         let chk_owner = |owner: &OwnerReference| owner.kind == "AttestationKey" && owner.name == ak_name;
         let refs = secret.and_then(|s| s.metadata.owner_references.as_ref());
         refs.map(|refs| refs.iter().any(chk_owner)).unwrap_or(false)
     };
-    let has_ak_owner = await_condition(secrets_api.clone(), &ak_name, chk_ak_owner);
+    let has_ak_owner = await_condition(secrets.clone(), &ak_name, chk_ak_owner);
     let ctx = format!("waiting for Secret {ak_name} to be owned by AttestationKey {ak_name}");
     timeout(scaled_duration(30), has_ak_owner).await.context(ctx)??;
 
@@ -327,11 +336,12 @@ async fn test_attestation_key_lifecycle() -> anyhow::Result<()> {
     machines.delete(&machine_name, &dp).await?;
     test_ctx.info(format!("Deleted Machine: {machine_name}"));
 
-    wait_for_resource_deleted(&machines, &machine_name, scaled_timeout(120)).await?;
+    let watch_machines: Api<Machine> = Api::namespaced(watch.clone(), namespace);
+    wait_for_resource_deleted(&watch_machines, &machine_name, scaled_timeout(120)).await?;
     test_ctx.info("Machine successfully deleted");
-    wait_for_resource_deleted(&attestation_keys, &ak_name, scaled_timeout(120)).await?;
+    wait_for_resource_deleted(&watch_aks, &ak_name, scaled_timeout(120)).await?;
     test_ctx.info("AttestationKey successfully deleted");
-    wait_for_resource_deleted(&secrets_api, &ak_name, scaled_timeout(120)).await?;
+    wait_for_resource_deleted(&secrets, &ak_name, scaled_timeout(120)).await?;
     test_ctx.info("Secret successfully deleted");
 
     test_ctx.cleanup().await?;
@@ -344,6 +354,7 @@ named_test! {
 async fn test_nonexistent_approved_image() -> anyhow::Result<()> {
     let test_ctx = setup!().await?;
     let client = test_ctx.client();
+    let watch = test_ctx.watch_client();
     let namespace = test_ctx.namespace();
 
     let images: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
@@ -364,7 +375,8 @@ async fn test_nonexistent_approved_image() -> anyhow::Result<()> {
         let cs = img.and_then(|img| img.status.as_ref()).and_then(|s| s.conditions.as_ref());
         cs.map(|cs| cs.iter().any(pending)).unwrap_or(false)
     };
-    let done = await_condition(images, "coreos1", is_pending);
+    let watch_images: Api<ApprovedImage> = Api::namespaced(watch.clone(), namespace);
+    let done = await_condition(watch_images, "coreos1", is_pending);
     let ctx = "waiting for ApprovedImage coreos1 to be PodPending";
     timeout(scaled_duration(30), done).await.context(ctx)??;
 
@@ -377,11 +389,13 @@ named_test! {
 async fn test_approved_image_readoption() -> anyhow::Result<()> {
     let test_ctx = setup!(delayed_approved_image).await?;
     let client = test_ctx.client();
+    let watch = test_ctx.watch_client();
     let namespace = test_ctx.namespace();
 
     let clusters: Api<TrustedExecutionCluster> = Api::namespaced(client.clone(), namespace);
     let images: Api<ApprovedImage> = Api::namespaced(client.clone(), namespace);
-    let configmaps: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    let watch_images: Api<ApprovedImage> = Api::namespaced(watch.clone(), namespace);
+    let configmaps: Api<ConfigMap> = Api::namespaced(watch.clone(), namespace);
 
     let cluster_spec = clusters.get(TEC_NAME).await?.spec;
     let image_spec = images.get(APPROVED_IMAGE_NAME).await?.spec;
@@ -390,14 +404,14 @@ async fn test_approved_image_readoption() -> anyhow::Result<()> {
         let refs = img.and_then(|img| img.metadata.owner_references.as_ref());
         refs.is_some_and(|refs| refs.iter().any(|o| o.kind == "TrustedExecutionCluster"))
     };
-    let done = await_condition(images.clone(), APPROVED_IMAGE_NAME, owned);
+    let done = await_condition(watch_images.clone(), APPROVED_IMAGE_NAME, owned);
     let ctx = "waiting for ApprovedImage to be owned by TrustedExecutionCluster";
     timeout(scaled_duration(30), done).await.context(ctx)??;
 
     test_ctx.info(format!("Deleting TrustedExecutionCluster {TEC_NAME}"));
     clusters.delete(TEC_NAME, &Default::default()).await?;
     wait_for_resource_deleted(&configmaps, TRUSTEE_CONFIG_MAP, scaled_timeout(60)).await?;
-    wait_for_resource_deleted(&images, APPROVED_IMAGE_NAME, scaled_timeout(60)).await?;
+    wait_for_resource_deleted(&watch_images, APPROVED_IMAGE_NAME, scaled_timeout(60)).await?;
     test_ctx.info(format!("Configmap {TRUSTEE_CONFIG_MAP} was removed"));
 
     let image = ApprovedImage {


### PR DESCRIPTION
Default kube-rs client has no read timeout so that watch operations are supported. Some non-watch operations have been seen to hang. Use a timeout of 30 seconds for such operations.

Introduce a structure to pass both clients where needed.

This yielded all successful runs for many hours on GHA CI and 4 passes on the notoriously flaky OpenShift CI.

Also:
- pass error if Machine cleanup fails
- reconcile ApprovedImages on job changes too for status updates
- use must-gather in GHA
- fix a log message and uses of `warn!` in ak-reg
- add timestamps to logging, which

Fixes: #227

@iroykaufman I also tested this with #248, here's the [rerere cache](https://git-scm.com/book/en/v2/Git-Tools-Rerere) already in case we merge this first: [rerere-timed-client.tar.gz](https://github.com/user-attachments/files/30561342/rerere-timed-client.tar.gz)

## Summary by Sourcery

Introduce a dual Kubernetes client setup with read timeouts for non-watch operations while preserving non-timed clients for watch-based controllers and tests, and update logging, controllers, tests, and CI accordingly.

New Features:
- Add a timed Kubernetes client with a 30-second read timeout for request/response API calls and expose it via the shared library.
- Introduce a KubeClients struct to pass both timed and watch-safe clients throughout the operator, services, test utilities, and virtual machine helpers.
- Extend the reference value image controller to own PCR-compute jobs so that ApprovedImage status and related resources reconcile correctly on job changes.

Bug Fixes:
- Ensure machine cleanup failures in the keygen controller surface as finalizer cleanup errors instead of being silently ignored.
- Use dedicated watch clients for long-lived streams and resource wait helpers to avoid hangs and improve reliability of operator controllers and integration tests.

Enhancements:
- Refactor operator, attestation-key-register, register-server, compute-pcrs, and test utilities to consistently use the new timed client for non-watch operations and a separate client for watches.
- Add timestamps to test logging and enable env_logger humantime formatting for clearer, time-correlated logs.
- Replace ad-hoc eprintln error logging with structured warn logging in the attestation key register secret reconciliation logic.
- Increase certain namespace and resource cleanup timeouts in tests to reduce flakiness on slower clusters.
- Adjust KubeVirt VM helpers to use the appropriate timed or watch clients for resource creation and readiness checks.

CI:
- Add a must-gather collection and artifact upload step to the GitHub Actions integration test workflow to aid in debugging CI failures.

Tests:
- Update integration and attestation tests to use separate timed and watch clients, including for await_condition and wait_for_resource_deleted calls, to improve stability across platforms.