### PR TITLE
dependabot: Block cert-manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
         versions: [">=0.24"]
       - dependency-name: "sigs.k8s.io/controller-tools"
         versions: [">=0.21"]
+      - dependency-name: "github.com/cert-manager/cert-manager"
+        versions: [">=1.21"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
With our goal to stay on k8s 1.35 for easier downstreaming, cert-manager must also be blocked or 1.36 will be pulled as transitive dependency.

## Summary by Sourcery

Build:
- Update Dependabot configuration to restrict cert-manager version upgrades to 1.21 or higher without advancing Kubernetes beyond 1.35.